### PR TITLE
Initial Project Claims KTable app and class to monitor a topic as a ktable

### DIFF
--- a/EventEnabledInsurance/ProjectionClaims/build.gradle
+++ b/EventEnabledInsurance/ProjectionClaims/build.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'java'
+}
+
+group 'org.example'
+version '1.0-SNAPSHOT'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testCompile group: 'junit', name: 'junit', version: '4.12'
+}

--- a/EventEnabledInsurance/ProjectionClaims/build.gradle
+++ b/EventEnabledInsurance/ProjectionClaims/build.gradle
@@ -11,4 +11,16 @@ repositories {
 
 dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
+
+    // https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients
+    compile group: 'org.apache.kafka', name: 'kafka-clients', version: '2.6.0'
+
+    // https://mvnrepository.com/artifact/org.apache.kafka/kafka-streams
+    compile group: 'org.apache.kafka', name: 'kafka-streams', version: '2.6.0'
+
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
+
+    // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
+    compile group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.30'
 }

--- a/EventEnabledInsurance/ProjectionClaims/readme.md
+++ b/EventEnabledInsurance/ProjectionClaims/readme.md
@@ -1,0 +1,3 @@
+
+Install IntelliJ IDEA Community edition from:
+https://www.jetbrains.com/idea/

--- a/EventEnabledInsurance/ProjectionClaims/settings.gradle
+++ b/EventEnabledInsurance/ProjectionClaims/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'ProjectionClaims'
+

--- a/EventEnabledInsurance/ProjectionClaims/src/main/java/com/ibm/cp4i/demos/eei/projectionclaims/Main.java
+++ b/EventEnabledInsurance/ProjectionClaims/src/main/java/com/ibm/cp4i/demos/eei/projectionclaims/Main.java
@@ -1,0 +1,9 @@
+package com.ibm.cp4i.demos.eei.projectionclaims;
+
+import static java.lang.System.out;
+
+public class Main {
+    public static void main (String[] args) {
+        out.println("Hello world");
+    }
+}

--- a/EventEnabledInsurance/ProjectionClaims/src/main/java/com/ibm/cp4i/demos/eei/projectionclaims/SystemOfRecordMonitor.java
+++ b/EventEnabledInsurance/ProjectionClaims/src/main/java/com/ibm/cp4i/demos/eei/projectionclaims/SystemOfRecordMonitor.java
@@ -44,7 +44,6 @@ public class SystemOfRecordMonitor {
      * @param scramUsername The "Credential Name" specified above.
      * @param scramPassword Get from the generated secret using:
      *   $ SCRAM_USERNAME=<Credential Name>
-     *   $ SCRAM_PASSWORD=$(oc get secret $SCRAM_USERNAME -o json | jq -r '.data.password' | base64 --decode)"
      *   $ SCRAM_PASSWORD=$(oc get secret $SCRAM_USERNAME -o json | jq -r '.data.password' | base64 --decode)
      *   $ echo "SCRAM_PASSWORD=$SCRAM_PASSWORD"
      */

--- a/EventEnabledInsurance/ProjectionClaims/src/main/java/com/ibm/cp4i/demos/eei/projectionclaims/SystemOfRecordMonitor.java
+++ b/EventEnabledInsurance/ProjectionClaims/src/main/java/com/ibm/cp4i/demos/eei/projectionclaims/SystemOfRecordMonitor.java
@@ -1,0 +1,160 @@
+package com.ibm.cp4i.demos.eei.projectionclaims;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+public class SystemOfRecordMonitor {
+    private final static String SOURCE_TOPIC = "sor.public.quotes";
+    private final static String STORE = "sor.store";
+    private final Properties properties = new Properties();
+    private ReadOnlyKeyValueStore<Bytes, Bytes> view = null;
+
+    public SystemOfRecordMonitor(String bootstrapServers) {
+        properties.put(StreamsConfig.APPLICATION_ID_CONFIG, SOURCE_TOPIC + "-cdc");
+        properties.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Bytes().getClass());
+        properties.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.Bytes().getClass());
+        properties.put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    }
+
+    /**
+     * If connecting to a secured bootstrap server then need to get this username/password from the EventStreams UI. Go
+     * to "Home" -> "Connect to this cluster" -> "Generate SCRAM credentials". Need to:
+     * - Specify the Credential Name.
+     * - Choose "Consume messages only, and read schemas"
+     * - Choose "All topics"
+     * - Choose "All consumer groups"
+     * - Choose "No transactional IDs"
+     * @param scramUsername The "Credential Name" specified above.
+     * @param scramPassword Get from the generated secret using:
+     *   $ SCRAM_USERNAME=<Credential Name>
+     *   $ SCRAM_PASSWORD=$(oc get secret $SCRAM_USERNAME -o json | jq -r '.data.password' | base64 --decode)"
+     *   $ SCRAM_PASSWORD=$(oc get secret $SCRAM_USERNAME -o json | jq -r '.data.password' | base64 --decode)
+     *   $ echo "SCRAM_PASSWORD=$SCRAM_PASSWORD"
+     */
+    public void addScramProperties(String scramUsername, String scramPassword) {
+        properties.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, "SASL_SSL");
+        properties.put(SaslConfigs.SASL_MECHANISM, "SCRAM-SHA-512");
+        String saslJaasConfig = "org.apache.kafka.common.security.scram.ScramLoginModule required username=\"" + scramUsername + "\" password=\"" + scramPassword + "\";";
+        properties.put(SaslConfigs.SASL_JAAS_CONFIG, saslJaasConfig);
+    }
+
+    /**
+     * If connecting to an external bootstrap server (not an internal service name) then this is needed. Go
+     * to "Home" -> "Connect to this cluster", then click Download Certificate" in the "PKCS12 certificate" box.
+     * @param truststorePath The path to the downloaded certificate
+     * @param password The password presented in the UI
+     */
+    public void addTLSProperties(String truststorePath, String password) {
+        properties.put(SslConfigs.SSL_PROTOCOL_CONFIG, "TLSv1.2");
+        properties.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, truststorePath);
+        properties.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, password);
+    }
+
+    public void start() {
+        StreamsBuilder builder = new StreamsBuilder();
+        builder.globalTable(SOURCE_TOPIC, Materialized.<Bytes, Bytes, KeyValueStore<Bytes, byte[]>>as(STORE));
+        KafkaStreams streams = new KafkaStreams(builder.build(), properties);
+        streams.start();
+        view = streams.store(STORE, QueryableStoreTypes.keyValueStore());
+    }
+
+    public JsonNode getRow(int quoteID) {
+        final JsonNode[] result = {null};
+        KeyValueIterator<Bytes, Bytes> all = view.all();
+        ObjectMapper mapper = new ObjectMapper();
+        all.forEachRemaining(keyValue -> {
+            if(result[0] == null) {
+                try {
+                    JsonNode json = mapper.readTree(new String(keyValue.value.get(), StandardCharsets.UTF_8));
+                    JsonNode after = json.get("payload").get("after");
+                    if(after.get("quoteid").asInt() == quoteID) {
+                        result[0] = after;
+                    }
+                } catch (JsonProcessingException exception) {
+                    exception.printStackTrace();
+                }
+            }
+        });
+        return result[0];
+    }
+
+    public JsonNode getTable() throws JsonProcessingException {
+        StringBuffer result = new StringBuffer();
+        result.append("[");
+
+        KeyValueIterator<Bytes, Bytes> all = view.all();
+        ObjectMapper mapper = new ObjectMapper();
+        final boolean[] needComma = {false};
+        all.forEachRemaining(keyValue -> {
+            try {
+                JsonNode json = mapper.readTree(new String(keyValue.value.get(), StandardCharsets.UTF_8));
+                JsonNode after = json.get("payload").get("after");
+                if(needComma[0]) {
+                    result.append(",");
+                }
+                needComma[0] = true;
+                result.append(after.toString());
+            } catch (JsonProcessingException exception) {
+                exception.printStackTrace();
+            }
+        });
+        result.append("]");
+        return mapper.readTree(result.toString());
+    }
+
+    public static void main(String[] args) {
+        SystemOfRecordMonitor monitor;
+        try {
+            monitor = new SystemOfRecordMonitor("minimal-prod-kafka-bootstrap-cp4i2.dan-debezium-e2e-ec111ed5d7db435e1c5eeeb4400d693f-0000.eu-gb.containers.appdomain.cloud:443");
+            monitor.addScramProperties("dan-test", "SCGg6kfxjJ1H");
+            monitor.addTLSProperties("/Users/daniel.pinkuk.ibm.com/Downloads/dan-test.p12", "VoA8LSmGY3rx");
+            monitor.start();
+        } catch (Throwable exception) {
+            exception.printStackTrace();
+            throw exception;
+        }
+        Integer id = null;
+        while (true) {
+            try {
+                Thread.sleep(5000);
+                JsonNode table = monitor.getTable();
+                System.out.println("===");
+                System.out.println(table.toPrettyString());
+                if(id == null) {
+                    JsonNode firstRow = table.get(0);
+                    if(firstRow != null) {
+                        id = firstRow.get("quoteid").intValue();
+                    }
+                }
+                if(id != null) {
+                    System.out.println("---");
+                    JsonNode row = monitor.getRow(id);
+                    if(row==null) {
+                        System.out.println("<null>");
+                    } else {
+                        System.out.println(row.toPrettyString());
+                    }
+                }
+            } catch (Throwable exception) {
+                exception.printStackTrace();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Example logs from:
- Start with empty quotes table
- Add 2 new rows
- Change the source for the 1st row to 'Dan'
```
14:49:00: Executing task 'SystemOfRecordMonitor.main()'...

Starting Gradle Daemon...
Connected to the target VM, address: '127.0.0.1:54621', transport: 'socket'
Gradle Daemon started in 1 s 68 ms
> Task :compileJava UP-TO-DATE
> Task :processResources NO-SOURCE
> Task :classes UP-TO-DATE
Connected to the VM started by ':SystemOfRecordMonitor.main()' (localhost:54629). Open the debugger session tab

> Task :SystemOfRecordMonitor.main()
[main] INFO org.apache.kafka.streams.StreamsConfig - StreamsConfig values: 
	acceptable.recovery.lag = 10000
	application.id = sor.public.quotes-cdc
	application.server = 
	bootstrap.servers = [minimal-prod-kafka-bootstrap-cp4i2.dan-debezium-e2e-ec111ed5d7db435e1c5eeeb4400d693f-0000.eu-gb.containers.appdomain.cloud:443]
	buffered.records.per.partition = 1000
	built.in.metrics.version = latest
	cache.max.bytes.buffering = 10485760
	client.id = 
	commit.interval.ms = 30000
	connections.max.idle.ms = 540000
	default.deserialization.exception.handler = class org.apache.kafka.streams.errors.LogAndFailExceptionHandler
	default.key.serde = class org.apache.kafka.common.serialization.Serdes$BytesSerde
	default.production.exception.handler = class org.apache.kafka.streams.errors.DefaultProductionExceptionHandler
	default.timestamp.extractor = class org.apache.kafka.streams.processor.FailOnInvalidTimestamp
	default.value.serde = class org.apache.kafka.common.serialization.Serdes$BytesSerde
	max.task.idle.ms = 0
	max.warmup.replicas = 2
	metadata.max.age.ms = 300000
	metric.reporters = []
	metrics.num.samples = 2
	metrics.recording.level = INFO
	metrics.sample.window.ms = 30000
	num.standby.replicas = 0
	num.stream.threads = 1
	partition.grouper = class org.apache.kafka.streams.processor.DefaultPartitionGrouper
	poll.ms = 100
	probing.rebalance.interval.ms = 600000
	processing.guarantee = at_least_once
	receive.buffer.bytes = 32768
	reconnect.backoff.max.ms = 1000
	reconnect.backoff.ms = 50
	replication.factor = 1
	request.timeout.ms = 40000
	retries = 0
	retry.backoff.ms = 100
	rocksdb.config.setter = null
	security.protocol = SASL_SSL
	send.buffer.bytes = 131072
	state.cleanup.delay.ms = 600000
	state.dir = /tmp/kafka-streams
	topology.optimization = none
	upgrade.from = null
	windowstore.changelog.additional.retention.ms = 86400000

[main] INFO org.apache.kafka.streams.KafkaStreams - stream-client [sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3] Kafka Streams version: 2.6.0
[main] INFO org.apache.kafka.streams.KafkaStreams - stream-client [sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3] Kafka Streams commit ID: 62abe01bee039651
[main] INFO org.apache.kafka.streams.KafkaStreams - stream-client [sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3] Overriding number of StreamThreads to zero for global-only topology
[main] INFO org.apache.kafka.clients.consumer.ConsumerConfig - ConsumerConfig values: 
	allow.auto.create.topics = true
	auto.commit.interval.ms = 5000
	auto.offset.reset = none
	bootstrap.servers = [minimal-prod-kafka-bootstrap-cp4i2.dan-debezium-e2e-ec111ed5d7db435e1c5eeeb4400d693f-0000.eu-gb.containers.appdomain.cloud:443]
	check.crcs = true
	client.dns.lookup = use_all_dns_ips
	client.id = sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-global-consumer
	client.rack = 
	connections.max.idle.ms = 540000
	default.api.timeout.ms = 60000
	enable.auto.commit = false
	exclude.internal.topics = true
	fetch.max.bytes = 52428800
	fetch.max.wait.ms = 500
	fetch.min.bytes = 1
	group.id = null
	group.instance.id = null
	heartbeat.interval.ms = 3000
	interceptor.classes = []
	internal.leave.group.on.close = false
	internal.throw.on.fetch.stable.offset.unsupported = false
	isolation.level = read_uncommitted
	key.deserializer = class org.apache.kafka.common.serialization.ByteArrayDeserializer
	max.partition.fetch.bytes = 1048576
	max.poll.interval.ms = 300000
	max.poll.records = 1000
	metadata.max.age.ms = 300000
	metric.reporters = []
	metrics.num.samples = 2
	metrics.recording.level = INFO
	metrics.sample.window.ms = 30000
	partition.assignment.strategy = [class org.apache.kafka.clients.consumer.RangeAssignor]
	receive.buffer.bytes = 65536
	reconnect.backoff.max.ms = 1000
	reconnect.backoff.ms = 50
	request.timeout.ms = 30000
	retry.backoff.ms = 100
	sasl.client.callback.handler.class = null
	sasl.jaas.config = [hidden]
	sasl.kerberos.kinit.cmd = /usr/bin/kinit
	sasl.kerberos.min.time.before.relogin = 60000
	sasl.kerberos.service.name = null
	sasl.kerberos.ticket.renew.jitter = 0.05
	sasl.kerberos.ticket.renew.window.factor = 0.8
	sasl.login.callback.handler.class = null
	sasl.login.class = null
	sasl.login.refresh.buffer.seconds = 300
	sasl.login.refresh.min.period.seconds = 60
	sasl.login.refresh.window.factor = 0.8
	sasl.login.refresh.window.jitter = 0.05
	sasl.mechanism = SCRAM-SHA-512
	security.protocol = SASL_SSL
	security.providers = null
	send.buffer.bytes = 131072
	session.timeout.ms = 10000
	ssl.cipher.suites = null
	ssl.enabled.protocols = [TLSv1.2]
	ssl.endpoint.identification.algorithm = https
	ssl.engine.factory.class = null
	ssl.key.password = null
	ssl.keymanager.algorithm = SunX509
	ssl.keystore.location = null
	ssl.keystore.password = null
	ssl.keystore.type = JKS
	ssl.protocol = TLSv1.2
	ssl.provider = null
	ssl.secure.random.implementation = null
	ssl.trustmanager.algorithm = PKIX
	ssl.truststore.location = /Users/daniel.pinkuk.ibm.com/Downloads/dan-test.p12
	ssl.truststore.password = [hidden]
	ssl.truststore.type = JKS
	value.deserializer = class org.apache.kafka.common.serialization.ByteArrayDeserializer

[main] INFO org.apache.kafka.common.security.authenticator.AbstractLogin - Successfully logged in.
[main] INFO org.apache.kafka.common.utils.AppInfoParser - Kafka version: 2.6.0
[main] INFO org.apache.kafka.common.utils.AppInfoParser - Kafka commitId: 62abe01bee039651
[main] INFO org.apache.kafka.common.utils.AppInfoParser - Kafka startTimeMs: 1599486545918
[main] INFO org.apache.kafka.clients.admin.AdminClientConfig - AdminClientConfig values: 
	bootstrap.servers = [minimal-prod-kafka-bootstrap-cp4i2.dan-debezium-e2e-ec111ed5d7db435e1c5eeeb4400d693f-0000.eu-gb.containers.appdomain.cloud:443]
	client.dns.lookup = use_all_dns_ips
	client.id = sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-admin
	connections.max.idle.ms = 300000
	default.api.timeout.ms = 60000
	metadata.max.age.ms = 300000
	metric.reporters = []
	metrics.num.samples = 2
	metrics.recording.level = INFO
	metrics.sample.window.ms = 30000
	receive.buffer.bytes = 65536
	reconnect.backoff.max.ms = 1000
	reconnect.backoff.ms = 50
	request.timeout.ms = 30000
	retries = 2147483647
	retry.backoff.ms = 100
	sasl.client.callback.handler.class = null
	sasl.jaas.config = [hidden]
	sasl.kerberos.kinit.cmd = /usr/bin/kinit
	sasl.kerberos.min.time.before.relogin = 60000
	sasl.kerberos.service.name = null
	sasl.kerberos.ticket.renew.jitter = 0.05
	sasl.kerberos.ticket.renew.window.factor = 0.8
	sasl.login.callback.handler.class = null
	sasl.login.class = null
	sasl.login.refresh.buffer.seconds = 300
	sasl.login.refresh.min.period.seconds = 60
	sasl.login.refresh.window.factor = 0.8
	sasl.login.refresh.window.jitter = 0.05
	sasl.mechanism = SCRAM-SHA-512
	security.protocol = SASL_SSL
	security.providers = null
	send.buffer.bytes = 131072
	ssl.cipher.suites = null
	ssl.enabled.protocols = [TLSv1.2]
	ssl.endpoint.identification.algorithm = https
	ssl.engine.factory.class = null
	ssl.key.password = null
	ssl.keymanager.algorithm = SunX509
	ssl.keystore.location = null
	ssl.keystore.password = null
	ssl.keystore.type = JKS
	ssl.protocol = TLSv1.2
	ssl.provider = null
	ssl.secure.random.implementation = null
	ssl.trustmanager.algorithm = PKIX
	ssl.truststore.location = /Users/daniel.pinkuk.ibm.com/Downloads/dan-test.p12
	ssl.truststore.password = [hidden]
	ssl.truststore.type = JKS

[main] WARN org.apache.kafka.clients.admin.AdminClientConfig - The configuration 'ssl.protocol' was supplied but isn't a known config.
[main] WARN org.apache.kafka.clients.admin.AdminClientConfig - The configuration 'ssl.truststore.location' was supplied but isn't a known config.
[main] WARN org.apache.kafka.clients.admin.AdminClientConfig - The configuration 'sasl.jaas.config' was supplied but isn't a known config.
[main] WARN org.apache.kafka.clients.admin.AdminClientConfig - The configuration 'ssl.truststore.password' was supplied but isn't a known config.
[main] INFO org.apache.kafka.common.utils.AppInfoParser - Kafka version: 2.6.0
[main] INFO org.apache.kafka.common.utils.AppInfoParser - Kafka commitId: 62abe01bee039651
[main] INFO org.apache.kafka.common.utils.AppInfoParser - Kafka startTimeMs: 1599486545996
[main] INFO org.apache.kafka.streams.KafkaStreams - stream-client [sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3] State transition from CREATED to REBALANCING
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.streams.state.internals.RocksDBTimestampedStore - Opening store sor.store in regular mode
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.streams.processor.internals.GlobalStateManagerImpl - global-stream-thread [sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] Restoring state for global store sor.store
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.clients.Metadata - [Consumer clientId=sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-global-consumer, groupId=null] Cluster ID: _GqfPwRYRmOXPDgXKsMDFA
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.clients.consumer.KafkaConsumer - [Consumer clientId=sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-global-consumer, groupId=null] Subscribed to partition(s): sor.public.quotes-0
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.clients.consumer.KafkaConsumer - [Consumer clientId=sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-global-consumer, groupId=null] Seeking to offset 50 for partition sor.public.quotes-0
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.clients.consumer.KafkaConsumer - [Consumer clientId=sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-global-consumer, groupId=null] Unsubscribed all topics or patterns and assigned partitions
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.clients.consumer.KafkaConsumer - [Consumer clientId=sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-global-consumer, groupId=null] Subscribed to partition(s): sor.public.quotes-0
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.clients.consumer.KafkaConsumer - [Consumer clientId=sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-global-consumer, groupId=null] Seeking to offset 65 for partition sor.public.quotes-0
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.streams.processor.internals.GlobalStreamThread - global-stream-thread [sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] State transition from CREATED to RUNNING
[sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3-GlobalStreamThread] INFO org.apache.kafka.streams.KafkaStreams - stream-client [sor.public.quotes-cdc-4581f2fb-635e-4222-9663-4c0e8dbc98c3] State transition from REBALANCING to RUNNING
===
[ ]
===
[ {
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
} ]
---
{
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}
===
[ {
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
} ]
---
{
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}
===
[ {
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}, {
  "quoteid" : 23,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
} ]
---
{
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}
===
[ {
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}, {
  "quoteid" : 23,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
} ]
---
{
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}
===
[ {
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}, {
  "quoteid" : 23,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
} ]
---
{
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}
===
[ {
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}, {
  "quoteid" : 23,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
} ]
---
{
  "quoteid" : 22,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}
===
[ {
  "quoteid" : 22,
  "source" : "Dan",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}, {
  "quoteid" : 23,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
} ]
---
{
  "quoteid" : 22,
  "source" : "Dan",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}
===
[ {
  "quoteid" : 22,
  "source" : "Dan",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}, {
  "quoteid" : 23,
  "source" : "Mobile",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
} ]
---
{
  "quoteid" : 22,
  "source" : "Dan",
  "name" : "Name",
  "email" : "EMail",
  "age" : 30,
  "address" : "Address",
  "usstate" : "USState",
  "licenseplate" : "LicensePlate",
  "descriptionofdamage" : "DescriptionOfDamage",
  "claimstatus" : 0,
  "claimcost" : null
}
Disconnected from the target VM, address: '127.0.0.1:54621', transport: 'socket'
14:49:56: Task execution finished 'SystemOfRecordMonitor.main()'.
```