### PR TITLE
Use latest tracing/data power/APIC

### DIFF
--- a/products/bash/deploy-og-sub.sh
+++ b/products/bash/deploy-og-sub.sh
@@ -28,6 +28,15 @@
 #
 namespace="cp4i"
 
+while getopts "n:" opt; do
+  case ${opt} in
+    n ) namespace="$OPTARG"
+      ;;
+    \? ) usage; exit
+      ;;
+  esac
+done
+
 # Get auth port with internal url and apply the operand config in common services namespace
 IAM_Update_OperandConfig() {
   export EXTERNAL=$(oc get configmap cluster-info -n kube-system -o jsonpath='{.data.master_public_url}')
@@ -51,36 +60,101 @@ function output_time {
 
 function wait_for_subscription {
   NAMESPACE=${1}
-  NAME=${2}
+  SOURCE=${2}
+  NAME=${3}
+  CHANNEL=${4}
+  SOURCE_NAMESPACE="openshift-marketplace"
+  SUBSCRIPTION_NAME="${NAME}-${CHANNEL}-${SOURCE}-${SOURCE_NAMESPACE}"
+
+  echo "Waiting for subscription \"${SUBSCRIPTION_NAME}\" in namespace \"${NAMESPACE}\""
 
   phase=""
   time=0
   wait_time=5
   until [[ "$phase" == "Succeeded" ]]; do
-    csv=$(oc get subscription -n ${NAMESPACE} ${NAME} -o json | jq -r .status.currentCSV)
+    csv=$(oc get subscription -n ${NAMESPACE} ${SUBSCRIPTION_NAME} -o json | jq -r .status.currentCSV)
     wait=0
     if [[ "$csv" == "null" ]]; then
-      echo "Waited for $(output_time $time), not got csv for subscription"
+      echo "  ${SUBSCRIPTION_NAME}: Not got csv"
       wait=1
     else
       phase=$(oc get csv -n ${NAMESPACE} $csv -o json | jq -r .status.phase)
       if [[ "$phase" != "Succeeded" ]]; then
-        echo "Waited for $(output_time $time), csv not in Succeeded phase, currently: $phase"
+        echo "  ${SUBSCRIPTION_NAME}: CSV \"$csv\" in phase \"${phase}\""
         wait=1
       fi
     fi
 
     if [[ "$wait" == "1" ]]; then
-      ((time=time+$wait_time))
-      if [ $time -gt 7200 ]; then
+      if [ $time -ge 7200 ]; then
         echo "ERROR: Failed after waiting for 120 minutes"
         exit 1
       fi
 
+      echo "Retrying in ${wait_time} seconds, waited for $(output_time $time) so far"
+      ((time=time+$wait_time))
       sleep $wait_time
     fi
   done
-  echo "$NAME has succeeded"
+  echo "$SUBSCRIPTION_NAME has succeeded"
+}
+
+function wait_for_all_subscriptions {
+  NAMESPACE=${1}
+  echo "Waiting for all subscriptions in namespace: $NAMESPACE"
+
+  all_succeeded="false"
+  time=0
+  wait_time=5
+  until [[ "$all_succeeded" == "true" ]]; do
+    all_succeeded="true"
+    subscriptions_succeeded=""
+    subscriptions_waiting=""
+
+    rows=$(oc get subscription -n ${NAMESPACE} -o json | jq -r '.items[] | { name: .metadata.name, csv: .status.currentCSV } | @base64')
+    for row in $rows; do
+      _jq() {
+       echo ${row} | base64 --decode | jq -r ${1}
+      }
+
+      SUBSCRIPTION_NAME=$(_jq '.name')
+      csv=$(_jq '.csv')
+
+      if [[ "$csv" == "null" ]]; then
+        all_succeeded="false"
+        subscriptions_waiting="${subscriptions_waiting}\n    ${SUBSCRIPTION_NAME}: Not got csv"
+      else
+        phase=$(oc get csv -n ${NAMESPACE} $csv -o json 2>/dev/null | jq -r .status.phase)
+        if [[ "$phase" != "Succeeded" ]]; then
+          subscriptions_waiting="${subscriptions_waiting}\n    ${SUBSCRIPTION_NAME}: CSV \"$csv\" in phase \"${phase}\""
+          all_succeeded="false"
+        else
+          subscriptions_succeeded="${subscriptions_succeeded}\n    ${SUBSCRIPTION_NAME}"
+        fi
+      fi
+    done
+
+    if [[ ! -z "$subscriptions_succeeded" ]]; then
+      echo -e "  The following subscriptions have succeeded:${subscriptions_succeeded}"
+    fi
+    if [[ ! -z "$subscriptions_waiting" ]]; then
+      echo -e "  Still waiting for the following subscriptions:${subscriptions_waiting}"
+    fi
+
+    if [[ "$all_succeeded" == "false" ]]; then
+      if [ $time -ge 7200 ]; then
+        echo "ERROR: Failed after waiting for 120 minutes"
+        exit 1
+      fi
+
+      echo "Retrying in ${wait_time} seconds, waited for $(output_time $time) so far"
+      ((time=time+$wait_time))
+      sleep $wait_time
+    fi
+
+  done
+
+  echo "All subscriptions in $NAMESPACE have succeeded"
 }
 
 function create_subscription {
@@ -104,18 +178,7 @@ spec:
   source: ${SOURCE}
   sourceNamespace: ${SOURCE_NAMESPACE}
 EOF
-
-  wait_for_subscription ${NAMESPACE} ${SUBSCRIPTION_NAME}
 }
-
-while getopts "n:" opt; do
-  case ${opt} in
-    n ) namespace="$OPTARG"
-      ;;
-    \? ) usage; exit
-      ;;
-  esac
-done
 
 cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1
@@ -128,27 +191,33 @@ spec:
     - ${namespace}
 EOF
 
-echo "INFO: Applying individual subscriptions for cp4i dependencies"
-create_subscription ${namespace} "opencloud-operators" "ibm-common-service-operator" "stable-v1"
-create_subscription ${namespace} "certified-operators" "couchdb-operator-certified" "v1.2"
-create_subscription ${namespace} "ibm-operator-catalog" "ibm-cloud-databases-redis-operator" "v1.1"
+# Create the subscription for navigator. This needs to be before APIC (ibm-apiconnect)
+# so APIC knows it's running in CP4I and before tracing (ibm-integration-operations-dashboard)
+# as tracing uses a CRD created by the navigator operator.
+echo "INFO: Applying subscription for platform navigator"
+create_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-platform-navigator" "v4.0"
+
+echo "INFO: Applying individual subscriptions for CP4I dependencies"
 create_subscription ${namespace} "ibm-operator-catalog" "aspera-hsts-operator" "v1.1"
 create_subscription ${namespace} "ibm-operator-catalog" "datapower-operator" "v1.0"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-appconnect" "v1.0"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-eventstreams" "v2.1"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-mq" "v1.1"
-create_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-operations-dashboard" "v1.0"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-asset-repository" "v1.0"
 
-# Apply the subscription for navigator. This needs to be before apic so apic knows it's running in cp4i
-echo "INFO: Applying subscription for platform navigator"
-create_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-platform-navigator" "v4.0"
+echo "INFO: Wait for platform navigator before applying the APIC/Tracing subscriptions"
+wait_for_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-platform-navigator" "v4.0"
 
+echo "INFO: Apply the APIC/Tracing subscriptions"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-apiconnect" "v1.0"
+create_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-operations-dashboard" "v2.0"
 
 # echo "INFO: Applying the subscription for the uber operator"
 # create_subscription ${namespace} "ibm-operator-catalog" "ibm-cp-integration" "v1.0"
 # echo "INFO: ClusterServiceVersion for the Platform Navigator is now installed, proceeding with installation..."
+
+echo "INFO: Wait for all subscriptions to succeed"
+wait_for_all_subscriptions ${namespace}
 
 # Wait for upto 10 minutes for the OperandConfig to appear in the common services namespace
 time=0

--- a/products/bash/deploy-og-sub.sh
+++ b/products/bash/deploy-og-sub.sh
@@ -78,7 +78,7 @@ function wait_for_subscription {
       echo "  ${SUBSCRIPTION_NAME}: Not got csv"
       wait=1
     else
-      phase=$(oc get csv -n ${NAMESPACE} $csv -o json | jq -r .status.phase)
+      phase=$(oc get csv -n ${NAMESPACE} $csv -o json 2>/dev/null | jq -r .status.phase)
       if [[ "$phase" != "Succeeded" ]]; then
         echo "  ${SUBSCRIPTION_NAME}: CSV \"$csv\" in phase \"${phase}\""
         wait=1

--- a/products/bash/deploy-og-sub.sh
+++ b/products/bash/deploy-og-sub.sh
@@ -41,7 +41,7 @@ done
 IAM_Update_OperandConfig() {
   export EXTERNAL=$(oc get configmap cluster-info -n kube-system -o jsonpath='{.data.master_public_url}')
   export INT_URL="${EXTERNAL}/.well-known/oauth-authorization-server"
-  export IAM_URL=$(curl $INT_URL | jq -r '.issuer')
+  export IAM_URL=$(curl $INT_URL 2>/dev/null | jq -r '.issuer')
   echo "INFO: External url: ${EXTERNAL}"
   echo "INFO: INT_URL: ${INT_URL}"
   echo "INFO: IAM URL : ${IAM_URL}"
@@ -199,7 +199,7 @@ create_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-platfor
 
 echo "INFO: Applying individual subscriptions for CP4I dependencies"
 create_subscription ${namespace} "ibm-operator-catalog" "aspera-hsts-operator" "v1.1"
-create_subscription ${namespace} "ibm-operator-catalog" "datapower-operator" "v1.0"
+create_subscription ${namespace} "ibm-operator-catalog" "datapower-operator" "v1.1"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-appconnect" "v1.0"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-eventstreams" "v2.1"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-mq" "v1.1"
@@ -209,7 +209,7 @@ echo "INFO: Wait for platform navigator before applying the APIC/Tracing subscri
 wait_for_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-platform-navigator" "v4.0"
 
 echo "INFO: Apply the APIC/Tracing subscriptions"
-create_subscription ${namespace} "ibm-operator-catalog" "ibm-apiconnect" "v1.0"
+create_subscription ${namespace} "ibm-operator-catalog" "ibm-apiconnect" "v2.0"
 create_subscription ${namespace} "ibm-operator-catalog" "ibm-integration-operations-dashboard" "v2.0"
 
 # echo "INFO: Applying the subscription for the uber operator"

--- a/products/bash/release-tracing.sh
+++ b/products/bash/release-tracing.sh
@@ -16,6 +16,7 @@
 #   -n : <namespace> (string), Defaults to "cp4i"
 #   -r : <release-name> (string), Defaults to "tracing-demo"
 #   -b : <block-storage-class> (string), Default to "ibmc-block-gold"
+#   -f : <file-storage-class> (string), Default to "ibmc-file-gold-gid"
 #
 # USAGE:
 #   With defaults values
@@ -31,10 +32,9 @@ function usage {
 namespace="cp4i"
 release_name="tracing-demo"
 block_storage="ibmc-block-gold"
-dynamic_resource=false
-dry_run=false
+file_storage="ibmc-file-gold-gid"
 
-while getopts "n:r:b:d" opt; do
+while getopts "n:r:b:d:f" opt; do
   case ${opt} in
     n ) namespace="$OPTARG"
       ;;
@@ -42,213 +42,32 @@ while getopts "n:r:b:d" opt; do
       ;;
     b ) block_storage="$OPTARG"
       ;;
-    d ) dynamic_resource=true
+    f ) file_storage="$OPTARG"
       ;;
     \? ) usage; exit
       ;;
   esac
 done
 
-if [[ "$dynamic_resource" == "true" ]]; then
-  csv=$(oc get csv -n ${namespace} -o custom-columns=:metadata.name --no-headers | grep ibm-integration-operations-dashboard)
-  echo "Getting resource from csv: $csv"
-  resource=$(oc get csv ${csv} -n ${namespace} -o jsonpath='{.metadata.annotations.alm-examples}' | \
-    jq -r '.[0]' | \
-    jq -r '.metadata.namespace |= "'${namespace}'"' | \
-    jq -r '.metadata.name |= "'${release_name}'"' | \
-    jq -r '.spec.global.storage.configDb.volumeClaimTemplate.spec.storageClassName |= "'${block_storage}'"' | \
-    jq -r '.spec.global.storage.store.volumeClaimTemplate.spec.storageClassName |= "'${block_storage}'"')
-else
-  resource=$(
-cat << EOF
-{
-  "apiVersion": "integration.ibm.com/v1beta1",
-  "kind": "OperationsDashboard",
-  "metadata": {
-    "labels": {
-      "app.kubernetes.io/instance": "ibm-integration-operations-dashboard",
-      "app.kubernetes.io/managed-by": "ibm-integration-operations-dashboard",
-      "app.kubernetes.io/name": "ibm-integration-operations-dashboard"
-    },
-    "name": "${release_name}",
-    "namespace": "${namespace}"
-  },
-  "spec": {
-    "global": {
-      "images": {
-        "configDb": "cp.icr.io/cp/icp4i/od/icp4i-od-config-db@sha256:ed92ca5a4c4f1afd014148db0f4a75944c2538f78bc18ec382f4c96adc153433",
-        "housekeeping": "cp.icr.io/cp/icp4i/od/icp4i-od-housekeeping@sha256:f923a8e9b61fa76cdfa413f0bd96890123735ff0d32508fe20e371097e8e4cd8",
-        "installAssist": "cp.icr.io/cp/icp4i/od/icp4i-od-install-assist@sha256:900c61098dce803b0be707318c77cb9a40df00c359c936b49c4ff162f2aa0cfb",
-        "legacyUi": "cp.icr.io/cp/icp4i/od/icp4i-od-legacy-ui@sha256:52396f272a6573c51338712fe8b8c0bc72fdf11db37308ef86894fd5b7401625",
-        "oidcConfigurator": "cp.icr.io/cp/icp4i/od/icp4i-od-oidc-configurator@sha256:b5ecb85c10f8716957bc0e3979f36ebc1e1fd800a270eb0065f310f0f9100b6b",
-        "pullPolicy": "IfNotPresent",
-        "registrationEndpoint": "cp.icr.io/cp/icp4i/od/icp4i-od-registration-endpoint@sha256:19947e936e00d5eab44e6ece88a6fa4cadbf846df8db1a4748fcf713ea9758e6",
-        "registrationProcessor": "cp.icr.io/cp/icp4i/od/icp4i-od-registration-processor@sha256:c8f5b57d26e411aaa46a26377d2e8e6c95ff862c73e74c935bfa0bb70c02adb6",
-        "reports": "cp.icr.io/cp/icp4i/od/icp4i-od-reports@sha256:e2bda58b1b820fea1b994c279a5fe33de36dd6ffb24eca04cea2f8b4693b968b",
-        "store": "cp.icr.io/cp/icp4i/od/icp4i-od-store@sha256:30492b1c025db622074355f38d713d0609db79000597f9e3fcd92cde142e8048",
-        "storeRetention": "cp.icr.io/cp/icp4i/od/icp4i-od-store-retention@sha256:a82da833b902f9db33ed94fb2b8558d202119a061810d0a791ad6b3bfcab1d5c",
-        "uiManager": "cp.icr.io/cp/icp4i/od/icp4i-od-ui-manager@sha256:c21d756a2ea6a06990bd464cec5674ef1fb9cdf07b1f4a50d1a6abf3784a84df",
-        "uiProxy": "cp.icr.io/cp/icp4i/od/icp4i-od-ui-proxy@sha256:72e00c40d51e6c27a854475985606f9de20c47738a2ab2c987e3bfdbcc2c57a0"
-      },
-      "replicas": {
-        "manager": 1,
-        "store": 1
-      },
-      "resources": {
-        "configDb": {
-          "limits": {
-            "cpu": "2",
-            "memory": "2048Mi"
-          },
-          "requests": {
-            "cpu": "0.5",
-            "memory": "1024Mi"
-          }
-        },
-        "housekeeping": {
-          "limits": {
-            "cpu": "1",
-            "memory": "2048Mi"
-          },
-          "requests": {
-            "cpu": "0.5",
-            "memory": "768Mi"
-          }
-        },
-        "initializationJobs": {
-          "limits": {
-            "cpu": "0.5",
-            "memory": "512Mi"
-          },
-          "requests": {
-            "cpu": "0.25",
-            "memory": "256Mi"
-          }
-        },
-        "legacyUi": {
-          "limits": {
-            "cpu": "1",
-            "memory": "2048Mi"
-          },
-          "requests": {
-            "cpu": "0.25",
-            "memory": "1024Mi"
-          }
-        },
-        "registrationEndpoint": {
-          "limits": {
-            "cpu": "0.5",
-            "memory": "1024Mi"
-          },
-          "requests": {
-            "cpu": "0.1",
-            "memory": "256Mi"
-          }
-        },
-        "registrationProcessor": {
-          "limits": {
-            "cpu": "0.5",
-            "memory": "1024Mi"
-          },
-          "requests": {
-            "cpu": "0.1",
-            "memory": "384Mi"
-          }
-        },
-        "reports": {
-          "limits": {
-            "cpu": "8",
-            "memory": "4096Mi"
-          },
-          "requests": {
-            "cpu": "0.5",
-            "memory": "1024Mi"
-          }
-        },
-        "store": {
-          "heapSize": "8192M",
-          "limits": {
-            "cpu": "4",
-            "memory": "10240Mi"
-          },
-          "requests": {
-            "cpu": "2",
-            "memory": "9216Mi"
-          }
-        },
-        "storeRetention": {
-          "limits": {
-            "cpu": "2",
-            "memory": "2048Mi"
-          },
-          "requests": {
-            "cpu": "0.8",
-            "memory": "768Mi"
-          }
-        },
-        "uiManager": {
-          "limits": {
-            "cpu": "4",
-            "memory": "4096Mi"
-          },
-          "requests": {
-            "cpu": "1",
-            "memory": "1024Mi"
-          }
-        },
-        "uiProxy": {
-          "limits": {
-            "cpu": "4",
-            "memory": "1024Mi"
-          },
-          "requests": {
-            "cpu": "0.2",
-            "memory": "512Mi"
-          }
-        }
-      },
-      "storage": {
-        "configDb": {
-          "type": "persistent-claim",
-          "volumeClaimTemplate": {
-            "spec": {
-              "resources": {
-                "requests": {
-                  "storage": "2Gi"
-                }
-              },
-              "storageClassName": "${block_storage}"
-            }
-          }
-        },
-        "store": {
-          "type": "persistent-claim",
-          "volumeClaimTemplate": {
-            "spec": {
-              "resources": {
-                "requests": {
-                  "storage": "10Gi"
-                }
-              },
-              "storageClassName": "${block_storage}"
-            }
-          }
-        }
-      }
-    },
-    "license": {
-      "accept": true
-    },
-    "version": "2020.2.1-0"
-  }
-}
+cat << EOF | oc apply -f -
+apiVersion: integration.ibm.com/v1beta2
+kind: OperationsDashboard
+metadata:
+  namespace: "${namespace}"
+  name: "${release_name}"
+  labels:
+    app.kubernetes.io/instance: ibm-integration-operations-dashboard
+    app.kubernetes.io/managed-by: ibm-integration-operations-dashboard
+    app.kubernetes.io/name: ibm-integration-operations-dashboard
+spec:
+  license:
+    accept: true
+  storage:
+    configDbVolume:
+      class: "${block_storage}"
+    sharedVolume:
+      class: "${block_storage}"
+    tracingVolume:
+      class: "${block_storage}"
+  version: 2020.3.1-0
 EOF
-)
-fi
-
-if [[ "$dry_run" == "true" ]]; then
-  echo "Would apply:"
-  echo "${resource}"
-else
-  echo "${resource}" | oc apply -f -
-fi


### PR DESCRIPTION
Use new channels for tracing, data power and APIC. Also change order and waiting. This should both speed up the subscription creation and also ensure APIC/tracing are created after navigator

This should fix the main install without demo prep. It includes a CR change for tracing to use the new tracing (the old CR is not supported with the new operator). Currently APIC is failing to install via demo prep, that will be addressed in a separate PR.