### PR TITLE
Create "extra" namespaces

### DIFF
--- a/products/bash/setup-demos.sh
+++ b/products/bash/setup-demos.sh
@@ -363,14 +363,10 @@ done
 # Add the required addons
 #-------------------------------------------------------------------------------------------------------------------
 $DEBUG && divider && echo "Addons:"
-if [[ $(echo $REQUIRED_ADDONS_JSON | jq -r '.' | jq length) -eq 0 ]]; then
-  ADDON_JSON=[]
-else
-  for row in $(echo "${REQUIRED_ADDONS_JSON}" | jq -r '.[] | select(.enabled == true ) | @base64'); do
-    ADDON_JSON=$(echo ${row} | base64 --decode)
-  done
-fi
-$DEBUG && echo $ADDON_JSON | jq .
+for row in $(echo "${REQUIRED_ADDONS_JSON}" | jq -r '.[] | select(.enabled == true ) | @base64'); do
+  ADDON_JSON=$(echo ${row} | base64 --decode)
+  $DEBUG && echo $ADDON_JSON | jq .
+done
 
 #-------------------------------------------------------------------------------------------------------------------
 # Display the required namespaces and create secrets and additional namespaces if does not exist

--- a/products/bash/setup-demos.sh
+++ b/products/bash/setup-demos.sh
@@ -377,7 +377,7 @@ $DEBUG && divider && echo "Namespaces:"
 oc get project $NAMESPACE 2>&1 >/dev/null
 if [ $? -ne 0 ]; then
   $DEBUG && echo -e "\n$cross [ERROR] Namespace '$NAMESPACE' does not exist"
-  update_status "[ERROR] Namespace '$NAMESPACE' does not exist" "namespace" "$FAILURE_CODE" "$($GET_UTC_TIME)" "Getting" "Failed" "$NAMESPACE"
+  update_status "Namespace '$NAMESPACE' does not exist" "namespace" "$FAILURE_CODE" "$($GET_UTC_TIME)" "Getting" "Failed" "$NAMESPACE"
 else
   $DEBUG && echo -e "\n$tick [SUCCESS] Namespace '$NAMESPACE' already exists"
   update_status "Namespace '$NAMESPACE' already exists" "namespace" "$SUCCESS_CODE" "$($GET_UTC_TIME)" "Getting" "Pending" "$NAMESPACE"


### PR DESCRIPTION
- Process the products list to get a list of extra namespaces. For each extra namespace (example: cp4i-ddd-test):
  - Create namespace if it doesn't exist
  - Copy the ibm-entitlement-key from the CR namespace
- The above should keep the status up to date as the changes are made