### PR TITLE
Add fixes found while testing the 2020.4.1 release

### DIFF
--- a/DrivewayDentDeletion/Operators/continuous-load.sh
+++ b/DrivewayDentDeletion/Operators/continuous-load.sh
@@ -55,7 +55,7 @@ TICK="\xE2\x9C\x85"
 CROSS="\xE2\x9D\x8C"
 ALL_DONE="\xF0\x9F\x92\xAF"
 INFO="\xE2\x84\xB9"
-POSTGRES_NAMESPACE=$NAMESPACE
+POSTGRES_NAMESPACE=
 DDD_TYPE="dev"
 DEFAULT_POSTGRES_CREDENTIAL_SECRET="postgres-credential-ddd"
 
@@ -99,6 +99,8 @@ while getopts "n:u:t:p:b:z:acdis" opt; do
     ;;
   esac
 done
+
+POSTGRES_NAMESPACE=${POSTGRES_NAMESPACE:-$NAMESPACE}
 
 echo "[INFO] Driveway dent deletion demo type: '$DDD_TYPE'"
 DB_USER=$(echo $NAMESPACE | sed 's/-/_/g')_${DDD_TYPE}_ddd

--- a/DrivewayDentDeletion/Operators/prereqs.sh
+++ b/DrivewayDentDeletion/Operators/prereqs.sh
@@ -40,7 +40,7 @@ CROSS="\xE2\x9D\x8C"
 ALL_DONE="\xF0\x9F\x92\xAF"
 INFO="\xE2\x84\xB9"
 SUFFIX="ddd"
-POSTGRES_NAMESPACE=$NAMESPACE
+POSTGRES_NAMESPACE=
 MISSING_PARAMS="false"
 OMIT_INITIAL_SETUP="false"
 WITH_TEST_TYPE=""
@@ -69,6 +69,8 @@ while getopts "n:op:r:" opt; do
     ;;
   esac
 done
+
+POSTGRES_NAMESPACE=${POSTGRES_NAMESPACE:-$NAMESPACE}
 
 if [[ -z "${NAMESPACE// /}" ]]; then
   echo -e "$CROSS [ERROR] Namespace for driveway dent deletion demo is empty. Please provide a value for '-n' parameter."

--- a/DrivewayDentDeletion/Operators/test-api-e2e.sh
+++ b/DrivewayDentDeletion/Operators/test-api-e2e.sh
@@ -37,7 +37,7 @@ CROSS="\xE2\x9D\x8C"
 NAMESPACE="cp4i"
 APIC=false
 os_sed_flag=""
-POSTGRES_NAMESPACE=$NAMESPACE
+POSTGRES_NAMESPACE=
 DDD_TYPE="dev"
 
 if [[ $(uname) == Darwin ]]; then
@@ -67,6 +67,8 @@ while getopts "n:p:s:ad:" opt; do
     ;;
   esac
 done
+
+POSTGRES_NAMESPACE=${POSTGRES_NAMESPACE:-$NAMESPACE}
 
 echo "Namespace passed: $NAMESPACE"
 echo "User name suffix: $USER_DB_SUFFIX"

--- a/EventEnabledInsurance/QuoteLifecycleSimulator/deploy.sh
+++ b/EventEnabledInsurance/QuoteLifecycleSimulator/deploy.sh
@@ -32,7 +32,7 @@ tick="\xE2\x9C\x85"
 cross="\xE2\x9D\x8C"
 all_done="\xF0\x9F\x92\xAF"
 SUFFIX="eei"
-POSTGRES_NAMESPACE=$namespace
+POSTGRES_NAMESPACE=
 PG_PORT=5432
 TICK_MILLIS=1000
 MOBILE_TEST_ROWS=10
@@ -47,6 +47,8 @@ while getopts "n:" opt; do
     ;;
   esac
 done
+
+POSTGRES_NAMESPACE=${POSTGRES_NAMESPACE:-$namespace}
 
 CURRENT_DIR=$(dirname $0)
 echo "INFO: Current directory: '$CURRENT_DIR'"

--- a/EventEnabledInsurance/build/build.sh
+++ b/EventEnabledInsurance/build/build.sh
@@ -40,7 +40,7 @@ tick="\xE2\x9C\x85"
 cross="\xE2\x9D\x8C"
 all_done="\xF0\x9F\x92\xAF"
 SUFFIX="eei"
-POSTGRES_NAMESPACE=$namespace
+POSTGRES_NAMESPACE=
 REPO="https://github.com/IBM/cp4i-deployment-samples.git"
 BRANCH="main"
 TKN=tkn
@@ -72,6 +72,8 @@ while getopts "n:r:b:t:f:g:" opt; do
     ;;
   esac
 done
+
+POSTGRES_NAMESPACE=${POSTGRES_NAMESPACE:-$namespace}
 
 if [[ -z "${namespace// /}" || -z "${REPO// /}" || -z "${BRANCH// /}" || -z "${TKN// /}" || -z "${DEFAULT_FILE_STORAGE// /}" || -z "${DEFAULT_FILE_STORAGE// /}" ]]; then
   echo -e "$cross ERROR: Mandatory parameters are empty"

--- a/EventEnabledInsurance/kafkaconnect/connector-postgres.yaml
+++ b/EventEnabledInsurance/kafkaconnect/connector-postgres.yaml
@@ -10,7 +10,7 @@ spec:
   tasksMax: 1
   config:
     # These are connection details to the Postgres database setup by the prereqs.
-    database.hostname: "postgresql.cp4i.svc.cluster.local"
+    database.hostname: "postgresql"
     database.port: "5432"
     # The following credentials refer to the mounted secret and use the FileConfigProvider
     # from the KafkaConnectS2I to extract properties from the properties file.

--- a/EventEnabledInsurance/prereqs.sh
+++ b/EventEnabledInsurance/prereqs.sh
@@ -42,12 +42,12 @@ TICK="\xE2\x9C\x85"
 CROSS="\xE2\x9D\x8C"
 ALL_DONE="\xF0\x9F\x92\xAF"
 SUFFIX="eei"
-POSTGRES_NAMESPACE=$NAMESPACE
+POSTGRES_NAMESPACE=
 REPO="https://github.com/IBM/cp4i-deployment-samples.git"
 BRANCH="main"
 INFO="\xE2\x84\xB9"
 MISSING_PARAMS="false"
-ELASTIC_NAMESPACE=$NAMESPACE
+ELASTIC_NAMESPACE=
 OMIT_INITIAL_SETUP=false
 DEFAULT_FILE_STORAGE="ibmc-file-gold-gid"
 DEFAULT_BLOCK_STORAGE="cp4i-block-performance"
@@ -83,6 +83,9 @@ while getopts "n:r:b:e:p:of:g:" opt; do
     ;;
   esac
 done
+
+POSTGRES_NAMESPACE=${POSTGRES_NAMESPACE:-$NAMESPACE}
+ELASTIC_NAMESPACE=${ELASTIC_NAMESPACE:-$NAMESPACE}
 
 if [[ -z "${NAMESPACE// /}" ]]; then
   echo -e "$CROSS [ERROR] Namespace for event enabled insurance demo is empty. Please provide a value for '-n' parameter."

--- a/EventEnabledInsurance/setup-elastic-search.sh
+++ b/EventEnabledInsurance/setup-elastic-search.sh
@@ -144,7 +144,7 @@ wait_for_subscription $ELASTIC_NAMESPACE $ELASTIC_SUBSCRIPTION_NAME
 
 echo -e "\n----------------------------------------------------------------------------------------------------------------------------------------------------------\n"
 
-json=$(oc get configmap -n $NAMESPACE operator-info -o json)
+json=$(oc get configmap -n $NAMESPACE operator-info -o json 2> /dev/null)
 if [[ $? == 0 ]]; then
   METADATA_NAME=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_NAME')
   METADATA_UID=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_UID')

--- a/products/bash/1-click-install.sh
+++ b/products/bash/1-click-install.sh
@@ -144,7 +144,7 @@ while getopts "a:b:c:d:e:f:g:h:j:k:l:m:n:o:p:q:r:s:t:u:v:w:x:y" opt; do
     CLUSTER_TYPE="$OPTARG"
     ;;
   y)
-    CLUSTER_SCOPED=true
+    CLUSTER_SCOPED="true"
     ;;
   \?)
     usage
@@ -331,7 +331,7 @@ divider
 if echo $CLUSTER_TYPE | grep -iqF roks; then
   # This storage class improves the pvc performance for small PVCs
   echo -e "$INFO [INFO] Creating new cp4i-block-performance storage class\n"
-  cat <<EOF | oc apply -n $JOB_NAMESPACE -f -
+  cat <<EOF | oc apply -f -
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/products/bash/configure-apic-v10.sh
+++ b/products/bash/configure-apic-v10.sh
@@ -349,8 +349,8 @@ ACE_CREDENTIALS=$(kubectl get secret $ACE_REGISTRATION_SECRET_NAME -n $NAMESPACE
 
 for i in $(seq 1 60); do
   PORTAL_WWW_POD=$(kubectl get pods -n $NAMESPACE | grep -m1 "${RELEASE_NAME}-ptl.*www" | awk '{print $1}')
-  PORTAL_SITE_UUID=$(kubectl exec -n $NAMESPACE -it $PORTAL_WWW_POD -c admin /opt/ibm/bin/list_sites | awk '{print $1}')
-  PORTAL_SITE_RESET_URL=$(kubectl exec -n $NAMESPACE -it $PORTAL_WWW_POD -c admin /opt/ibm/bin/site_login_link $PORTAL_SITE_UUID | tail -1)
+  PORTAL_SITE_UUID=$(kubectl exec -n $NAMESPACE -it $PORTAL_WWW_POD -c admin -- /opt/ibm/bin/list_sites | awk '{print $1}')
+  PORTAL_SITE_RESET_URL=$(kubectl exec -n $NAMESPACE -it $PORTAL_WWW_POD -c admin -- /opt/ibm/bin/site_login_link $PORTAL_SITE_UUID | tail -1)
   if [[ "$PORTAL_SITE_RESET_URL" =~ "https://$PTL_WEB_EP" ]]; then
     printf "$tick"
     echo "[OK] Got the portal_site_password_reset_link"

--- a/products/bash/create-ace-config.sh
+++ b/products/bash/create-ace-config.sh
@@ -39,7 +39,7 @@ CROSS="\xE2\x9D\x8C"
 INFO="\xE2\x84\xB9"
 TICK="\xE2\x9C\x85"
 NAMESPACE="cp4i"
-POSTGRES_NAMESPACE=$NAMESPACE
+POSTGRES_NAMESPACE=
 DB_USER="cp4i"
 DB_NAME="db_cp4i"
 DB_PASS=""
@@ -112,6 +112,8 @@ while getopts "n:g:u:d:p:s:t" opt; do
     ;;
   esac
 done
+
+POSTGRES_NAMESPACE=${POSTGRES_NAMESPACE:-$NAMESPACE}
 
 if [[ -z "$DEBUG" ]]; then
   DEBUG="false"

--- a/products/bash/deploy-og-sub.sh
+++ b/products/bash/deploy-og-sub.sh
@@ -184,7 +184,7 @@ spec:
 EOF
 }
 
-if [[ "$CLUSTER_SCOPED" == "false" ]]; then
+if [[ "$CLUSTER_SCOPED" != "true" ]]; then
   cat <<EOF | oc apply -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup

--- a/products/bash/release-ace-dashboard.sh
+++ b/products/bash/release-ace-dashboard.sh
@@ -64,7 +64,7 @@ if [[ "$production" == "true" ]]; then
 
 fi
 
-json=$(oc get configmap -n $namespace operator-info -o json)
+json=$(oc get configmap -n $namespace operator-info -o json 2> /dev/null)
 if [[ $? == 0 ]]; then
   METADATA_NAME=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_NAME')
   METADATA_UID=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_UID')

--- a/products/bash/release-ace-designer.sh
+++ b/products/bash/release-ace-designer.sh
@@ -51,7 +51,7 @@ echo "INFO: Release ACE Designer..."
 echo "INFO: Namespace: '$namespace'"
 echo "INFO: Designer Release Name: '$designer_release_name'"
 
-json=$(oc get configmap -n $namespace operator-info -o json)
+json=$(oc get configmap -n $namespace operator-info -o json 2> /dev/null)
 if [[ $? == 0 ]]; then
   METADATA_NAME=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_NAME')
   METADATA_UID=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_UID')

--- a/products/bash/release-apic.sh
+++ b/products/bash/release-apic.sh
@@ -60,7 +60,7 @@ if [[ "$production" == "true" ]]; then
   profile="n12xc4.m12"
 fi
 
-json=$(oc get configmap -n $namespace operator-info -o json)
+json=$(oc get configmap -n $namespace operator-info -o json 2> /dev/null)
 if [[ $? == 0 ]]; then
   METADATA_NAME=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_NAME')
   METADATA_UID=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_UID')

--- a/products/bash/release-ar.sh
+++ b/products/bash/release-ar.sh
@@ -30,7 +30,7 @@ function usage() {
 namespace="cp4i"
 release_name="demo"
 assetDataVolume="ibmc-file-gold-gid"
-couchVolume="ibmc-block-gold"
+couchVolume="cp4i-block-performance"
 
 while getopts "n:r:a:c:" opt; do
   case ${opt} in
@@ -53,7 +53,7 @@ while getopts "n:r:a:c:" opt; do
   esac
 done
 
-json=$(oc get configmap -n $namespace operator-info -o json)
+json=$(oc get configmap -n $namespace operator-info -o json 2> /dev/null)
 if [[ $? == 0 ]]; then
   METADATA_NAME=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_NAME')
   METADATA_UID=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_UID')

--- a/products/bash/release-ar.sh
+++ b/products/bash/release-ar.sh
@@ -24,13 +24,13 @@
 #     ./release-ar.sh -n cp4i-prod -r prod
 
 function usage() {
-  echo "Usage: $0 -n <namespace> -r <release-name>"
+  echo "Usage: $0 -n <namespace> -r <release-name> -a <assets storage class (file)> -c <couch storage class (block)>"
 }
 
 namespace="cp4i"
 release_name="demo"
 assetDataVolume="ibmc-file-gold-gid"
-couchVolume="cp4i-block-performance"
+couchVolume="ibmc-block-gold"
 
 while getopts "n:r:a:c:" opt; do
   case ${opt} in

--- a/products/bash/release-es.sh
+++ b/products/bash/release-es.sh
@@ -53,7 +53,7 @@ while getopts "n:r:pc:" opt; do
   esac
 done
 
-json=$(oc get configmap -n $namespace operator-info -o json)
+json=$(oc get configmap -n $namespace operator-info -o json 2> /dev/null)
 if [[ $? == 0 ]]; then
   METADATA_NAME=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_NAME')
   METADATA_UID=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_UID')

--- a/products/bash/release-mq.sh
+++ b/products/bash/release-mq.sh
@@ -90,7 +90,7 @@ elif [[ "$release_name" =~ "eei" ]]; then
   numberOfContainers=1
 fi
 
-json=$(oc get configmap -n $namespace operator-info -o json)
+json=$(oc get configmap -n $namespace operator-info -o json 2> /dev/null)
 if [[ $? == 0 ]]; then
   METADATA_NAME=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_NAME')
   METADATA_UID=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_UID')

--- a/products/bash/release-tracing.sh
+++ b/products/bash/release-tracing.sh
@@ -59,7 +59,7 @@ while getopts "n:r:b:d:f:p" opt; do
   esac
 done
 
-json=$(oc get configmap -n $namespace operator-info -o json)
+json=$(oc get configmap -n $namespace operator-info -o json 2> /dev/null)
 if [[ $? == 0 ]]; then
   METADATA_NAME=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_NAME')
   METADATA_UID=$(echo $json | tr '\r\n' ' ' | jq -r '.data.METADATA_UID')


### PR DESCRIPTION
Summary of changes:
- Fixed postgres/elastic search namespaces if not specified to default to the specified main namespace (scripts would only have worked if using the cp4i namespace)
- Fixed the postgres hostname in the EEI postgres connector to not specify a namespace (assumed cp4i)
- Made the get of the operator-info config map not output an error when running without the operator (avoiding clutter in logs)


1-click test using this branch succeeded:
https://cloud.ibm.com/schematics/workspaces/us-south.workspace.ibm-cp-integration-03-03-2021.5e91d4dd/activity?region=
