### PR TITLE
Use release catalog images

### DIFF
--- a/products/bash/1-click-install.sh
+++ b/products/bash/1-click-install.sh
@@ -418,7 +418,7 @@ fi
 
 divider
 
-if ! $CURRENT_DIR/create-catalog-sources.sh -p; then
+if ! $CURRENT_DIR/create-catalog-sources.sh; then
   echo -e "$CROSS [ERROR] Failed to create catalog sources"
   divider
   exit 1

--- a/products/bash/create-catalog-sources.sh
+++ b/products/bash/create-catalog-sources.sh
@@ -243,28 +243,9 @@ spec:
       interval: 45m
 ---
 EOF
-
-
 else
   echo -e "$INFO [INFO] Using the release catalog sources"
   cat <<EOF | oc apply -f -
----
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: opencloud-operators
-  namespace: openshift-marketplace
-spec:
-  displayName: IBMCS Operators
-  publisher: IBM
-  sourceType: grpc
-  image: docker.io/ibmcom/ibm-common-service-catalog:latest
-  updateStrategy:
-    registryPoll:
-      interval: 45m
-
----
-
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
@@ -274,7 +255,7 @@ spec:
   displayName: ibm-operator-catalog
   publisher: IBM Content
   sourceType: grpc
-  image: docker.io/ibmcom/ibm-operator-catalog
+  image: icr.io/cpopen/ibm-operator-catalog:latest
   updateStrategy:
     registryPoll:
       interval: 45m

--- a/products/bash/deploy-og-sub.sh
+++ b/products/bash/deploy-og-sub.sh
@@ -273,29 +273,27 @@ if [[ "${pre_release}" == "true" ]]; then
   wait_for_subscription ${namespace} ${NAVIGATOR_CATALOG} "ibm-integration-platform-navigator" "v5.0"
   create_subscription ${namespace} ${ASPERA_CATALOG} "aspera-hsts-operator" "v1.2-eus"
   wait_for_subscription ${namespace} ${ASPERA_CATALOG} "aspera-hsts-operator" "v1.2-eus"
-  create_subscription ${namespace} ${ACE_CATALOG} "ibm-appconnect" "v1.3"
-  wait_for_subscription ${namespace} ${ACE_CATALOG} "ibm-appconnect" "v1.3"
+  create_subscription ${namespace} ${ACE_CATALOG} "ibm-appconnect" "v1.5"
+  wait_for_subscription ${namespace} ${ACE_CATALOG} "ibm-appconnect" "v1.5"
   create_subscription ${namespace} ${ES_CATALOG} "ibm-eventstreams" "v2.3"
   wait_for_subscription ${namespace} ${ES_CATALOG} "ibm-eventstreams" "v2.3"
-
   create_subscription ${namespace} ${MQ_CATALOG} "ibm-mq" "v1.5"
   wait_for_subscription ${namespace} ${MQ_CATALOG} "ibm-mq" "v1.5"
   create_subscription ${namespace} ${AR_CATALOG} "ibm-integration-asset-repository" "v1.3"
   wait_for_subscription ${namespace} ${AR_CATALOG} "ibm-integration-asset-repository" "v1.3"
 else
-  create_subscription ${namespace} ${NAVIGATOR_CATALOG} "ibm-integration-platform-navigator" "v4.2"
-  wait_for_subscription ${namespace} ${NAVIGATOR_CATALOG} "ibm-integration-platform-navigator" "v4.2"
+  create_subscription ${namespace} ${NAVIGATOR_CATALOG} "ibm-integration-platform-navigator" "v5.0"
+  wait_for_subscription ${namespace} ${NAVIGATOR_CATALOG} "ibm-integration-platform-navigator" "v5.0"
   create_subscription ${namespace} ${ASPERA_CATALOG} "aspera-hsts-operator" "v1.2-eus"
   wait_for_subscription ${namespace} ${ASPERA_CATALOG} "aspera-hsts-operator" "v1.2-eus"
-  create_subscription ${namespace} ${ACE_CATALOG} "ibm-appconnect" "v1.3"
-  wait_for_subscription ${namespace} ${ACE_CATALOG} "ibm-appconnect" "v1.3"
+  create_subscription ${namespace} ${ACE_CATALOG} "ibm-appconnect" "v1.5"
+  wait_for_subscription ${namespace} ${ACE_CATALOG} "ibm-appconnect" "v1.5"
   create_subscription ${namespace} ${ES_CATALOG} "ibm-eventstreams" "v2.3"
   wait_for_subscription ${namespace} ${ES_CATALOG} "ibm-eventstreams" "v2.3"
-
   create_subscription ${namespace} ${MQ_CATALOG} "ibm-mq" "v1.5"
   wait_for_subscription ${namespace} ${MQ_CATALOG} "ibm-mq" "v1.5"
-  create_subscription ${namespace} ${AR_CATALOG} "ibm-integration-asset-repository" "v1.2"
-  wait_for_subscription ${namespace} ${AR_CATALOG} "ibm-integration-asset-repository" "v1.2"
+  create_subscription ${namespace} ${AR_CATALOG} "ibm-integration-asset-repository" "v1.3"
+  wait_for_subscription ${namespace} ${AR_CATALOG} "ibm-integration-asset-repository" "v1.3"
 fi
 
 if [[ "${DEPLOY_DEMOS}" == "true" ]]; then
@@ -310,12 +308,10 @@ echo "INFO: ClusterServiceVersion for the Platform Navigator is now installed, p
 echo "INFO: Apply the APIC/Tracing subscriptions"
 if [[ "${pre_release}" == "true" ]]; then
   create_subscription ${namespace} ${APIC_CATALOG} "ibm-apiconnect" "v2.3"
-
   create_subscription ${namespace} ${OD_CATALOG} "ibm-integration-operations-dashboard" "v2.3"
 else
-  create_subscription ${namespace} ${APIC_CATALOG} "ibm-apiconnect" "v2.2"
-
-  create_subscription ${namespace} ${OD_CATALOG} "ibm-integration-operations-dashboard" "v2.2"
+  create_subscription ${namespace} ${APIC_CATALOG} "ibm-apiconnect" "v2.3"
+  create_subscription ${namespace} ${OD_CATALOG} "ibm-integration-operations-dashboard" "v2.3"
 fi
 
 echo "INFO: Wait for all subscriptions to succeed"


### PR DESCRIPTION
Using images from the following CASEs:
- ibm-ai-wmltraining-1.0.0
- ibm-apiconnect-3.0.1
- ibm-appconnect-1.5.0
- ibm-aspera-hsts-operator-1.2.2
- ibm-automation-foundation-core-1.1.0
- ibm-cloud-databases-redis-1.3.0
- ibm-cp-common-services-1.5.0
- ibm-cp-integration-2.3.0
- ibm-datapower-operator-cp4i-1.4.0
- ibm-eventstreams-1.3.1
- ibm-integration-asset-repository-1.3.1
- ibm-integration-demos-operator-1.0.0
- ibm-integration-operations-dashboard-2.3.1
- ibm-integration-platform-navigator-1.3.0
- ibm-mq-1.5.1

Tested non-demo 1-click install on `fermi-carol` (`cp4i1` namespace)