### PR TITLE
Adding in the new syntax to trigger Event Listener

### DIFF
--- a/DrivewayDentDeletion/Operators/test-ddd.sh
+++ b/DrivewayDentDeletion/Operators/test-ddd.sh
@@ -133,7 +133,7 @@ function wait_and_trigger_pipeline() {
   echo -e "$INFO [INFO] The event listener pod:\n"
   oc get pod -n $NAMESPACE | grep el-$PIPELINE_TYPE-event-listener | grep 1/1 | grep Running
   echo -e "\n$INFO [INFO] The event listener pod is now in Running, going ahead to trigger the '$PIPELINE_TYPE' pipeline...\n"
-  curl -X POST $URL --header \"Content-Type: application/json\" --data '{\"message\":\"Test run\"}'\n"
+  curl -X POST $URL --header "Content-Type: application/json" --data '{"message":"Test run"}'
 
   divider
 

--- a/DrivewayDentDeletion/Operators/test-ddd.sh
+++ b/DrivewayDentDeletion/Operators/test-ddd.sh
@@ -133,7 +133,7 @@ function wait_and_trigger_pipeline() {
   echo -e "$INFO [INFO] The event listener pod:\n"
   oc get pod -n $NAMESPACE | grep el-$PIPELINE_TYPE-event-listener | grep 1/1 | grep Running
   echo -e "\n$INFO [INFO] The event listener pod is now in Running, going ahead to trigger the '$PIPELINE_TYPE' pipeline...\n"
-  curl $URL
+  curl -X POST $URL --header \"Content-Type: application/json\" --data '{\"message\":\"Test run\"}'\n"
 
   divider
 


### PR DESCRIPTION
### Description of Change
Latest Version of OCP Pipelines require the Event Listener call to be a POST with a Body and so the `curl` call in the `test-ddd` script needed updating in line with syntax referenced at https://github.com/IBM/cp4i-deployment-samples/blob/2021.3.1/DrivewayDentDeletion/Operators/cicd-apply-dev-pipeline.sh#L228


### Verification of Change
- Has been verified by Fermi Squad internally but the implementation of that change was missed in this script. So just adding it there. 