### PR TITLE
Fix the publisher/display name for the ibm-operator-catalog catalog source

### DIFF
--- a/products/bash/create-catalog-sources.sh
+++ b/products/bash/create-catalog-sources.sh
@@ -252,8 +252,8 @@ metadata:
   name: ibm-operator-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: ibm-operator-catalog
-  publisher: IBM Content
+  displayName: IBM Operator Catalog
+  publisher: IBM
   sourceType: grpc
   image: icr.io/cpopen/ibm-operator-catalog:latest
   updateStrategy:


### PR DESCRIPTION
Catalog source fixed, now shows:
```
$ oc get catalogsource -n openshift-marketplace ibm-operator-catalog
NAME                   DISPLAY                TYPE   PUBLISHER   AGE
ibm-operator-catalog   IBM Operator Catalog   grpc   IBM         3h24m
```