### PR TITLE
Fix APIC password generation

### DIFF
--- a/products/bash/create-catalog-sources.sh
+++ b/products/bash/create-catalog-sources.sh
@@ -252,8 +252,8 @@ metadata:
   name: ibm-operator-catalog
   namespace: openshift-marketplace
 spec:
-  displayName: ibm-operator-catalog
-  publisher: IBM Content
+  displayName: IBM Operator Catalog
+  publisher: IBM
   sourceType: grpc
   image: icr.io/cpopen/ibm-operator-catalog:latest
   updateStrategy:

--- a/products/bash/generate-apic-password.sh
+++ b/products/bash/generate-apic-password.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+#******************************************************************************
+# Licensed Materials - Property of IBM
+# (c) Copyright IBM Corporation 2020. All Rights Reserved.
+#
+# Note to U.S. Government Users Restricted Rights:
+# Use, duplication or disclosure restricted by GSA ADP Schedule
+# Contract with IBM Corp.
+#******************************************************************************
+
+function maxRepeatingChars() {
+  PASSWORD=${1}
+
+  previousCharacter=${PASSWORD:0:1}
+  repeatCount=1
+  maxRepeatCount=1
+
+  for (( i=1; i<${#PASSWORD}; i++ )); do
+    character=${PASSWORD:$i:1}
+    if [[ "$character" == "${previousCharacter}" ]]; then
+      ((repeatCount=repeatCount+1))
+      if [ "$repeatCount" -gt "$maxRepeatCount" ]; then
+        maxRepeatCount=$repeatCount
+      fi
+    else
+      repeatCount=1
+    fi
+    previousCharacter=$character
+  done
+
+  echo "$maxRepeatCount"
+}
+
+function validateAPICPassword() {
+  PASSWORD=${1}
+  if [ "${#PASSWORD}" -lt "8" ]; then
+    echo "false: Too short"
+    return
+  fi
+  characterTypeCount=0
+  if [[ "$PASSWORD" =~ [[:lower:]] ]]; then
+    ((characterTypeCount=characterTypeCount+1))
+  fi
+  if [[ "$PASSWORD" =~ [[:upper:]] ]]; then
+    ((characterTypeCount=characterTypeCount+1))
+  fi
+  if [[ "$PASSWORD" =~ [0-9] ]]; then
+    ((characterTypeCount=characterTypeCount+1))
+  fi
+  if [ "$characterTypeCount" -lt "2" ]; then
+    echo "false: Not enough character types"
+    return
+  fi
+  if [ "$(maxRepeatingChars $PASSWORD)" -ge "3" ]; then
+    echo "false: Too many repeating characters"
+    return
+  fi
+
+  echo "true"
+}
+
+function generateAPICPassword() {
+  valid="false"
+  until [ "$valid" == "true" ]; do
+    APIC_PASSWORD=$(
+      LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 16
+      echo
+    )
+    valid=$(validateAPICPassword $APIC_PASSWORD)
+  done
+  echo $APIC_PASSWORD
+}

--- a/products/bash/pub-sub-apic.sh
+++ b/products/bash/pub-sub-apic.sh
@@ -37,6 +37,7 @@
 # ↡ publish product to catalog
 
 CURRENT_DIR=$(dirname $0)
+source ${CURRENT_DIR}/generate-apic-password.sh
 
 TICK="\xE2\x9C\x85"
 CROSS="\xE2\x9D\x8C"
@@ -53,7 +54,7 @@ TARGET_URL=""
 PRODUCT_YAML_TEMPLATE="DrivewayDentDeletion/Operators/apic-resources/apic-product-ddd.yaml"
 SWAGGER_YAML_TEMPLATE="DrivewayDentDeletion/Operators/apic-resources/apic-api-ddd.yaml"
 # TODO
-DEBUG=true
+DEBUG=false
 
 function usage() {
   echo "Usage: $0 -e <ENVIRONMENT> -n <MAIN_NAMESPACE> -r <RELEASE> -d <DEMO_NAME> -t <TARGET_URL> -p <PRODUCT_YAML_TEMPLATE> -s <SWAGGER_YAML_TEMPLATE>"
@@ -312,10 +313,7 @@ $DEBUG && echo "[DEBUG] User registry url: ${USER_REGISTRY_URL}"
 echo -e "[INFO] ${TICK} Got configured catalog user registry url for ${ORG}-catalog"
 
 CORG_OWNER_USERNAME="${ORG}-corg-admin"
-CORG_OWNER_PASSWORD=$(
-  LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 16
-  echo
-)
+CORG_OWNER_PASSWORD=$(generateAPICPassword)
 $DEBUG && echo "[DEBUG] username: $CORG_OWNER_USERNAME"
 $DEBUG && echo "[DEBUG] password: ${CORG_OWNER_PASSWORD}"
 # Create consumer org owner

--- a/products/bash/test-generate-apic-password.sh
+++ b/products/bash/test-generate-apic-password.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#******************************************************************************
+# Licensed Materials - Property of IBM
+# (c) Copyright IBM Corporation 2020. All Rights Reserved.
+#
+# Note to U.S. Government Users Restricted Rights:
+# Use, duplication or disclosure restricted by GSA ADP Schedule
+# Contract with IBM Corp.
+#******************************************************************************
+
+source $(dirname $0)/generate-apic-password.sh
+
+testPasswords="Ug0k6662TjhRslLA abc ABC 0123 aB0123456789 aBCDEFGH a0123456789 B0123456789 Azzzzzzzzzz AAAAAAAz ABCDEFGHIJ"
+for testPassword in $testPasswords
+do
+  echo "---"
+  echo "testPassword: $testPassword"
+  echo "Length: ${#testPassword}"
+  echo "Max repeating characters: $(maxRepeatingChars $testPassword)"
+  echo "Password valid: $(validateAPICPassword $testPassword)"
+done
+
+echo "---"
+echo "Old password generation"
+invalidCount=0
+for i in $(seq 1 100000); do
+  APIC_PASSWORD=$(
+    LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 16
+    echo
+  )
+  valid=$(validateAPICPassword $APIC_PASSWORD)
+  if [ "$valid" != "true" ]; then
+    ((invalidCount=invalidCount+1))
+    echo "$i: Password: $APIC_PASSWORD, valid: $(validateAPICPassword $APIC_PASSWORD)"
+  fi
+done
+echo "Invalid count: ${invalidCount}"
+
+echo "---"
+echo "New password generation"
+invalidCount=0
+for i in $(seq 1 100000); do
+  APIC_PASSWORD=$(generateAPICPassword)
+  valid=$(validateAPICPassword $APIC_PASSWORD)
+  if [ "$valid" != "true" ]; then
+    ((invalidCount=invalidCount+1))
+    echo "$i: Password: $APIC_PASSWORD, valid: $(validateAPICPassword $APIC_PASSWORD)"
+  fi
+done
+echo "Invalid count: ${invalidCount}"


### PR DESCRIPTION
Retry if generated password is invalid

Logs from running test-generate-apic-password.sh:
[test-log.txt](https://github.com/IBM/cp4i-deployment-samples/files/7497855/test-log.txt)
This shows the old method of generating the password failed about 0.3% of the time.

DDD pipeline also tested:
![image](https://user-images.githubusercontent.com/64848511/140766825-88cc9b06-8f01-4036-9f5b-90f4fcca15a7.png)
