### PR TITLE
typo in test pipeline + patching DP GW replicas

### DIFF
--- a/DrivewayDentDeletion/Operators/cicd-test-apic/cicd-pipeline.yaml
+++ b/DrivewayDentDeletion/Operators/cicd-test-apic/cicd-pipeline.yaml
@@ -381,7 +381,7 @@ spec:
           value: "products/bash/release-ace-integration-server.sh"
         - name: params
           # For Test deploy with tracing disabled and HA
-          value: "-n {{NAMESPACE}} -a {{HA_ENABLED}} -r ddd-dev-ace-chris -i image-registry.openshift-image-registry.svc:5000/{{NAMESPACE}}/ddd-ace-chris:$(params.imageTag)-test -d policyproject-ddd-test"
+          value: "-n {{NAMESPACE}} -a {{HA_ENABLED}} -r ddd-test-ace-chris -i image-registry.openshift-image-registry.svc:5000/{{NAMESPACE}}/ddd-ace-chris:$(params.imageTag)-test -d policyproject-ddd-test"
       workspaces:
         - name: git-source
           workspace: git-source

--- a/DrivewayDentDeletion/Operators/cicd-test/cicd-pipeline.yaml
+++ b/DrivewayDentDeletion/Operators/cicd-test/cicd-pipeline.yaml
@@ -383,7 +383,7 @@ spec:
           value: "products/bash/release-ace-integration-server.sh"
         - name: params
           # For Test deploy with tracing disabled and HA
-          value: "-n {{NAMESPACE}} -a {{HA_ENABLED}} -r ddd-dev-ace-chris -i image-registry.openshift-image-registry.svc:5000/{{NAMESPACE}}/ddd-ace-chris:$(params.imageTag)-test -d policyproject-ddd-test"
+          value: "-n {{NAMESPACE}} -a {{HA_ENABLED}} -r ddd-test-ace-chris -i image-registry.openshift-image-registry.svc:5000/{{NAMESPACE}}/ddd-ace-chris:$(params.imageTag)-test -d policyproject-ddd-test"
       workspaces:
         - name: git-source
           workspace: git-source

--- a/products/bash/configure-apic-v10.sh
+++ b/products/bash/configure-apic-v10.sh
@@ -410,7 +410,7 @@ if [[ "$ha_enabled" == "true" ]]; then
       sleep 10
     fi
   done
-  oc patch -n ${NAMESPACE} GatewayCluster/${RELEASE_NAME}-gw --patch '{"spec":{"profile":"n3xc4.m8"}}' --type=merge
+  oc patch -n ${NAMESPACE} GatewayCluster/${RELEASE_NAME}-gw --patch '{"spec":{"profile":"n3xc4.m8","replicaCount":3}}' --type=merge
 fi
 
 


### PR DESCRIPTION
Following our discussion in Slack: https://ibm-cloud.slack.com/archives/G01ERHZM1S9/p1637145387101700?thread_ts=1636619963.084200&cid=G01ERHZM1S9

This PR contains two main changes:

1. Fixing typo from dev to test for `ddd-dev-ace-chris` to `ddd-test-ace-chris`
Issue linked: https://github.ibm.com/cp4i/icip-issues/issues/3273

2. Patching DataPower GW to scale pods to 3 for HA mode
Issue linked: https://github.ibm.com/cp4i/icip-issues/issues/3274


CPSVT build for those changes (passed):

- https://travis.ibm.com/automation-base-pak/cp-svt-travis/builds/59705824

@DanRoseus @AnjaliSrivastava29 