### PR TITLE
Improve EEI resiliency

### DIFF
--- a/CommonPipelineResources/cicd-tasks.yaml
+++ b/CommonPipelineResources/cicd-tasks.yaml
@@ -103,5 +103,5 @@ spec:
     - name: git-source
   steps:
     - name: oc
-      image: quay.io/openshift/origin-cli:4.6.0
+      image: quay.io/openshift/origin-cli:latest
       script: "/workspace/git-source/$(params.script) $(params.params)"

--- a/DrivewayDentDeletion/Operators/cicd-test-apic/cicd-tasks.yaml
+++ b/DrivewayDentDeletion/Operators/cicd-test-apic/cicd-tasks.yaml
@@ -70,7 +70,7 @@ spec:
       description: The PVC to use for layers
   steps:
     - name: pull-retag-push-to-test
-      image: quay.io/openshift/origin-cli:4.6.0
+      image: quay.io/openshift/origin-cli:latest
       script: |
         oc tag -n {{NAMESPACE}} $(params.imageName):$(params.imageTag) $(params.imageName):$(params.imageTag)-test
 
@@ -91,7 +91,7 @@ spec:
     - name: git-source
   steps:
     - name: oc
-      image: quay.io/openshift/origin-cli:4.6.0
+      image: quay.io/openshift/origin-cli:latest
       script: "/workspace/git-source/DrivewayDentDeletion/Operators/test-api-e2e.sh -n {{NAMESPACE}} -s $(params.suffix) -d $(params.dddType) -a"
 
 ---
@@ -114,5 +114,5 @@ spec:
     - name: git-source
   steps:
     - name: oc
-      image: quay.io/openshift/origin-cli:4.6.0
+      image: quay.io/openshift/origin-cli:latest
       script: "/workspace/git-source/products/bash/$(params.releaseScript) -n {{NAMESPACE}} -r $(params.releaseName) -e $(params.environment)"

--- a/DrivewayDentDeletion/Operators/cicd-test/cicd-tasks.yaml
+++ b/DrivewayDentDeletion/Operators/cicd-test/cicd-tasks.yaml
@@ -16,7 +16,7 @@ spec:
       description: The PVC to use for layers
   steps:
     - name: pull-retag-push-to-test
-      image: quay.io/openshift/origin-cli:4.6.0
+      image: quay.io/openshift/origin-cli:latest
       script: |
         oc tag -n {{NAMESPACE}} $(params.imageName):$(params.imageTag) $(params.imageName):$(params.imageTag)-test
 
@@ -37,5 +37,5 @@ spec:
     - name: git-source
   steps:
     - name: oc
-      image: quay.io/openshift/origin-cli:4.6.0
+      image: quay.io/openshift/origin-cli:latest
       script: "/workspace/git-source/DrivewayDentDeletion/Operators/test-api-e2e.sh -n {{NAMESPACE}} -s $(params.suffix) -d $(params.dddType)"

--- a/EventEnabledInsurance/build/pipeline.yaml
+++ b/EventEnabledInsurance/build/pipeline.yaml
@@ -10,6 +10,7 @@ spec:
     - name: git-source
   tasks:
     - name: git-clone-eei
+      retries: 2
       taskRef:
         name: git-clone
         kind: ClusterTask
@@ -27,6 +28,7 @@ spec:
           workspace: git-source
 
     - name: fixup-dockerfiles
+      retries: 2
       runAfter:
         - git-clone-eei
       taskRef:
@@ -42,6 +44,7 @@ spec:
 
     # build simulator app image
     - name: build-simulator-image
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -61,6 +64,7 @@ spec:
 
     # deploy simulator app image
     - name: deploy-simulator-app
+      retries: 2
       runAfter:
         - build-simulator-image
       taskRef:
@@ -76,6 +80,7 @@ spec:
 
     # build projection claim app image
     - name: build-projection-claims-image
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -95,6 +100,7 @@ spec:
 
     # deploy projection claim app image
     - name: deploy-projection-claims-app
+      retries: 2
       runAfter:
         - build-projection-claims-image
       taskRef:
@@ -110,6 +116,7 @@ spec:
 
     # build mq image
     - name: build-mq-image
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -129,6 +136,7 @@ spec:
 
     # deploy mq image
     - name: deploy-mq
+      retries: 2
       runAfter:
         - build-mq-image
       taskRef:
@@ -144,6 +152,7 @@ spec:
 
     # build ace rest
     - name: build-ace-rest
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -165,6 +174,7 @@ spec:
 
     # build ace db-writer
     - name: build-ace-db-writer
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -186,6 +196,7 @@ spec:
 
     # deploy ace rest
     - name: deploy-ace-rest
+      retries: 2
       runAfter:
         - build-ace-rest
       taskRef:
@@ -201,6 +212,7 @@ spec:
 
     # deploy ace db_writer
     - name: deploy-db-writer
+      retries: 2
       runAfter:
         - build-ace-db-writer
       taskRef:
@@ -215,6 +227,7 @@ spec:
           workspace: git-source
 
     - name: push-to-apic
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:


### PR DESCRIPTION
1) Avoid deleting the PVC/PipelineRuns on failure. Instead delete the old ones before running so on retry (I.e. if the operator re-reconciles) it starts fresh.
2) Add retries to the pipeline tasks
3) Use the latest oc image