### PR TITLE
Add task retries for DDD pipelines

### DIFF
--- a/DrivewayDentDeletion/Operators/cicd-dev/cicd-pipeline.yaml
+++ b/DrivewayDentDeletion/Operators/cicd-dev/cicd-pipeline.yaml
@@ -11,6 +11,7 @@ spec:
     - name: git-source
   tasks:
     - name: clone-git-source
+      retries: 2
       taskRef:
         name: git-clone
         kind: ClusterTask
@@ -28,6 +29,7 @@ spec:
           workspace: git-source
 
     - name: fixup-dockerfiles
+      retries: 2
       runAfter:
         - clone-git-source
       taskRef:
@@ -43,6 +45,7 @@ spec:
 
     # MQ build in dev namespace
     - name: build-mq
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -64,6 +67,7 @@ spec:
 
     # MQ deploy in dev namesapce
     - name: deploy-wait-mq
+      retries: 2
       runAfter:
         - build-mq
       taskRef:
@@ -80,6 +84,7 @@ spec:
 
     # build all ace in dev namespace
     - name: build-ace-int-server-ace-api
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -100,6 +105,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-acme
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -120,6 +126,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-bernie
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -140,6 +147,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-chris
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -161,6 +169,7 @@ spec:
 
     # deploy all ace in dev namespace
     - name: deploy-wait-ace-api
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-api
       taskRef:
@@ -176,6 +185,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-bernie
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-bernie
       taskRef:
@@ -191,6 +201,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-acme
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-acme
       taskRef:
@@ -206,6 +217,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-chris
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-chris
       taskRef:

--- a/DrivewayDentDeletion/Operators/cicd-test-apic/cicd-pipeline.yaml
+++ b/DrivewayDentDeletion/Operators/cicd-test-apic/cicd-pipeline.yaml
@@ -11,6 +11,7 @@ spec:
     - name: git-source
   tasks:
     - name: clone-git-source
+      retries: 2
       taskRef:
         name: git-clone
         kind: ClusterTask
@@ -28,6 +29,7 @@ spec:
           workspace: git-source
 
     - name: fixup-dockerfiles
+      retries: 2
       runAfter:
         - clone-git-source
       taskRef:
@@ -43,6 +45,7 @@ spec:
 
     # MQ build for dev
     - name: build-mq
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -64,6 +67,7 @@ spec:
 
     # MQ deploy for dev
     - name: deploy-wait-mq
+      retries: 2
       runAfter:
         - build-mq
       taskRef:
@@ -80,6 +84,7 @@ spec:
 
     # build all ace for dev
     - name: build-ace-int-server-ace-api
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -100,6 +105,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-acme
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -120,6 +126,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-bernie
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -140,6 +147,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-chris
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -161,6 +169,7 @@ spec:
 
     # deploy all ace for dev
     - name: deploy-wait-ace-api
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-api
       taskRef:
@@ -176,6 +185,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-bernie
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-bernie
       taskRef:
@@ -191,6 +201,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-acme
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-acme
       taskRef:
@@ -206,6 +217,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-chris
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-chris
       taskRef:
@@ -222,6 +234,7 @@ spec:
 
     # test end-to-end API for dev
     - name: test-e2e-api-in-dev-namespace
+      retries: 2
       runAfter:
         - apic-resource-config-dev
         - deploy-wait-ace-chris
@@ -242,6 +255,7 @@ spec:
 
     # push ace images to test namespace
     - name: image-push-to-test-ace-chris
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -253,7 +267,9 @@ spec:
           value: "ddd-ace-chris"
         - name: pvc
           value: "buildah-ace-chris"
+
     - name: image-push-to-test-ace-acme
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -265,7 +281,9 @@ spec:
           value: "ddd-ace-acme"
         - name: pvc
           value: "buildah-ace-acme"
+
     - name: image-push-to-test-ace-bernie
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -277,7 +295,9 @@ spec:
           value: "ddd-ace-bernie"
         - name: pvc
           value: "buildah-ace-bernie"
+
     - name: image-push-to-test-ace-api
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -292,6 +312,7 @@ spec:
 
     # push mq image to test namespace
     - name: image-push-to-test-mq
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -308,6 +329,7 @@ spec:
 
     # Deploy MQ for test
     - name: deploy-wait-mq-test
+      retries: 2
       runAfter:
         - image-push-to-test-mq
       taskRef:
@@ -324,6 +346,7 @@ spec:
 
     # deploy all ace api for test
     - name: deploy-wait-ace-api-test
+      retries: 2
       runAfter:
         - image-push-to-test-ace-api
       taskRef:
@@ -340,6 +363,7 @@ spec:
 
     # deploy all ace bernie in test namespace
     - name: deploy-wait-ace-bernie-test
+      retries: 2
       runAfter:
         - image-push-to-test-ace-bernie
       taskRef:
@@ -356,6 +380,7 @@ spec:
 
     # deploy all ace acme for test
     - name: deploy-wait-ace-acme-test
+      retries: 2
       runAfter:
         - image-push-to-test-ace-acme
       taskRef:
@@ -372,6 +397,7 @@ spec:
 
     # deploy all ace chris for test
     - name: deploy-wait-ace-chris-test
+      retries: 2
       runAfter:
         - image-push-to-test-ace-chris
       taskRef:
@@ -387,6 +413,7 @@ spec:
           workspace: git-source
 
     - name: apic-resource-config-dev
+      retries: 2
       runAfter:
         - deploy-wait-ace-chris
         - deploy-wait-mq
@@ -407,6 +434,7 @@ spec:
           workspace: git-source
 
     - name: apic-resource-config-test
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
         - deploy-wait-ace-chris-test
@@ -429,6 +457,7 @@ spec:
 
     # test end-to-end API for test
     - name: test-e2e-api-in-test-namespace
+      retries: 2
       runAfter:
         - apic-resource-config-test
         - deploy-wait-ace-chris-test

--- a/DrivewayDentDeletion/Operators/cicd-test/cicd-pipeline.yaml
+++ b/DrivewayDentDeletion/Operators/cicd-test/cicd-pipeline.yaml
@@ -11,6 +11,7 @@ spec:
     - name: git-source
   tasks:
     - name: clone-git-source
+      retries: 2
       taskRef:
         name: git-clone
         kind: ClusterTask
@@ -28,6 +29,7 @@ spec:
           workspace: git-source
 
     - name: fixup-dockerfiles
+      retries: 2
       runAfter:
         - clone-git-source
       taskRef:
@@ -43,6 +45,7 @@ spec:
 
     # MQ build for dev
     - name: build-mq
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -64,6 +67,7 @@ spec:
 
     # MQ deploy for dev
     - name: deploy-wait-mq
+      retries: 2
       runAfter:
         - build-mq
       taskRef:
@@ -80,6 +84,7 @@ spec:
 
     # build all ace for dev
     - name: build-ace-int-server-ace-api
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -100,6 +105,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-acme
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -120,6 +126,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-bernie
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -140,6 +147,7 @@ spec:
           workspace: git-source
 
     - name: build-ace-int-server-ace-chris
+      retries: 2
       runAfter:
         - fixup-dockerfiles
       taskRef:
@@ -161,6 +169,7 @@ spec:
 
     # deploy all ace for dev
     - name: deploy-wait-ace-api
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-api
       taskRef:
@@ -176,6 +185,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-bernie
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-bernie
       taskRef:
@@ -191,6 +201,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-acme
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-acme
       taskRef:
@@ -206,6 +217,7 @@ spec:
           workspace: git-source
 
     - name: deploy-wait-ace-chris
+      retries: 2
       runAfter:
         - build-ace-int-server-ace-chris
       taskRef:
@@ -222,6 +234,7 @@ spec:
 
     # test end-to-end API in dev namespace
     - name: test-e2e-api-in-dev-namespace
+      retries: 2
       runAfter:
         - deploy-wait-ace-chris
         - deploy-wait-mq
@@ -241,6 +254,7 @@ spec:
 
     # push ace images for test
     - name: image-push-to-test-ace-chris
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -254,6 +268,7 @@ spec:
           value: "buildah-ace-chris"
 
     - name: image-push-to-test-ace-acme
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -267,6 +282,7 @@ spec:
           value: "buildah-ace-acme"
 
     - name: image-push-to-test-ace-bernie
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -280,6 +296,7 @@ spec:
           value: "buildah-ace-bernie"
 
     - name: image-push-to-test-ace-api
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -294,6 +311,7 @@ spec:
 
     # push mq image to test namespace
     - name: image-push-to-test-mq
+      retries: 2
       runAfter:
         - test-e2e-api-in-dev-namespace
       taskRef:
@@ -310,6 +328,7 @@ spec:
 
     # Deploy MQ for test
     - name: deploy-wait-mq-test
+      retries: 2
       runAfter:
         - image-push-to-test-mq
       taskRef:
@@ -326,6 +345,7 @@ spec:
 
     # deploy all ace api in test namespace
     - name: deploy-wait-ace-api-test
+      retries: 2
       runAfter:
         - image-push-to-test-ace-api
       taskRef:
@@ -342,6 +362,7 @@ spec:
 
     # deploy all ace bernie in test namespace
     - name: deploy-wait-ace-bernie-test
+      retries: 2
       runAfter:
         - image-push-to-test-ace-bernie
       taskRef:
@@ -358,6 +379,7 @@ spec:
 
     # deploy all ace acme for test
     - name: deploy-wait-ace-acme-test
+      retries: 2
       runAfter:
         - image-push-to-test-ace-acme
       taskRef:
@@ -374,6 +396,7 @@ spec:
 
     # deploy all ace chris for test
     - name: deploy-wait-ace-chris-test
+      retries: 2
       runAfter:
         - image-push-to-test-ace-chris
       taskRef:
@@ -390,6 +413,7 @@ spec:
 
     # test end-to-end API in test namespace
     - name: test-e2e-api-in-test-namespace
+      retries: 2
       runAfter:
         - deploy-wait-ace-chris-test
         - deploy-wait-mq-test


### PR DESCRIPTION
For testing the pipeline was run 10 times on a Fyre cluster, passing all 10:
<img width="1319" alt="image" src="https://user-images.githubusercontent.com/64848511/161707970-1702e1ea-f9fd-442b-bd1b-0823b9b95351.png">

I also did 2 tests against ROKS using the Jenkins job. First run:
<img width="818" alt="image" src="https://user-images.githubusercontent.com/64848511/161708166-1c342476-753b-4d48-a71b-9174eecee3be.png">
The 1 failure was during the prereq validation due to a test problem with concurrently using/updating the oc command line tool.

Second run:
<img width="814" alt="image" src="https://user-images.githubusercontent.com/64848511/161708238-d2c48a1e-538c-4706-9c96-d911e1f67190.png">
The 1 failure was while changing the CS admin password, something new to investigate later! :
```
log-1171)[2022-04-05T01:15:04.167Z]     INFO: Waiting for the platform-auth-idp-credentials secret to appear
[2022-04-05T01:15:04.167Z]     NAME                            TYPE     DATA   AGE
[2022-04-05T01:15:04.167Z]     platform-auth-idp-credentials   Opaque   2      30m
[2022-04-05T01:15:04.167Z]     INFO: Found the secret platform-auth-idp-credentials in the namespace 'ibm-common-services'
[2022-04-05T01:15:04.167Z]     INFO: Waiting for Common Services console route
[2022-04-05T01:15:04.167Z]     INFO: CP_USERNAME: admin
[2022-04-05T01:15:04.167Z]     INFO: CP_CONSOLE: cp-console.auto-1-click-fcd-3-ec111ed5d7db435e1c5eeeb4400d693f-0000.eu-gb.containers.appdomain.cloud
[2022-04-05T01:15:04.167Z]     INFO: Downloading cloudctl
[2022-04-05T01:15:04.167Z]     INFO: Doing the cloudctl login
[2022-04-05T01:15:04.167Z]     INFO: cloudctl login succeeded
[2022-04-05T01:15:04.167Z]     INFO: Updating the admin password
[2022-04-05T01:15:04.167Z]      [ERROR] Failed to update the common services admin username/password
```