### PR TITLE
Add retries for changing the cs credentials

### DIFF
--- a/products/bash/1-click-install.sh
+++ b/products/bash/1-click-install.sh
@@ -505,13 +505,18 @@ divider
 
 # Only update common services username and password if common services is not already installed
 if [ "$PASSWORD_CHANGE" == "true" ]; then
-  if ! $CURRENT_DIR/change-cs-credentials.sh -u "$csDefaultAdminUser" -p "$csDefaultAdminPassword"; then
-    echo -e "$CROSS [ERROR] Failed to update the common services admin username/password"
-    divider
-    exit 1
-  else
-    echo -e "$TICK [SUCCESS] Successfully updated the common services admin username/password"
-  fi
+  time=0
+  until $CURRENT_DIR/change-cs-credentials.sh -u "$csDefaultAdminUser" -p "$csDefaultAdminPassword"; do
+    if [ $time -gt 10 ]; then
+      echo -e "$CROSS [ERROR] Failed to update the common services admin username/password"
+      exit 1
+    fi
+    echo -e "$INFO [INFO] Failed to update the common services admin username/password, retrying in 1 minute"
+    time=$((time + 1))
+    sleep 60
+  done
+
+  echo -e "$TICK [SUCCESS] Successfully updated the common services admin username/password"
 else
   echo -e "$INFO [INFO] Retrieve the common service username using the command 'oc get secrets -n ibm-common-services platform-auth-idp-credentials -o jsonpath='{.data.admin_username}' | base64 --decode' "
   echo -e "$INFO [INFO] Retrieve the common service password using the command 'oc get secrets -n ibm-common-services platform-auth-idp-credentials -o jsonpath='{.data.admin_password}' | base64 --decode' "


### PR DESCRIPTION
Before this PR we were seeing a roughly 30% failure rate due to changing the CS admin password. Post this change:
<img width="875" alt="image" src="https://user-images.githubusercontent.com/64848511/164627759-7a48cbb7-958e-4d46-b338-cc8a1f6ba589.png">
<img width="877" alt="image" src="https://user-images.githubusercontent.com/64848511/164627827-57be2824-e1a4-4d86-89a0-0a101368176d.png">

That's 19/20 1-click installs succeeding. For the last one it's got past changing the CS admin password, got as far as waiting for APIC to start up, then looks like Jenkins stopped running the script.