### PR TITLE
Feat: Added support for large APIC names

### DIFF
--- a/products/bash/configure-apic-v10.sh
+++ b/products/bash/configure-apic-v10.sh
@@ -106,7 +106,7 @@ if [ "$APIC_STATUS" != "Ready" ]; then
 fi
 
 for i in $(seq 1 60); do
-  PORTAL_WWW_POD=$(oc get pods -n $NAMESPACE | grep -m1 "${RELEASE_NAME}-ptl.*www" | awk '{print $1}')
+  PORTAL_WWW_POD=$(oc get pods -n $NAMESPACE | grep -m1 "${RELEASE_NAME:0:10}-.*-www" | awk '{print $1}')
   if [ -z "$PORTAL_WWW_POD" ]; then
     echo "Not got portal pod yet"
   else
@@ -127,12 +127,19 @@ done
 echo "Pod listing for information"
 oc get pod -n $NAMESPACE
 
+# obtain different APIC v10 routes names
+APIM_UI_RESOURCE_NAME=$(oc get routes -n $NAMESPACE | grep -m1 "${RELEASE_NAME:0:10}.*api-manager" | awk '{print $1}')
+CMC_UI_RESOURCE_NAME=$(oc get routes -n $NAMESPACE | grep -m1 "${RELEASE_NAME:0:10}.*admin" | awk '{print $1}')
+C_API_RESOURCE_NAME=$(oc get routes -n $NAMESPACE | grep -m1 "${RELEASE_NAME:0:10}.*consumer-api" | awk '{print $1}')
+API_RESOURCE_NAME=$(oc get routes -n $NAMESPACE | grep -m1 "${RELEASE_NAME:0:10}.*platform-api" | awk '{print $1}')
+PLT_WEB_RESOURCE_NAME=$(oc get routes -n $NAMESPACE | grep -m1 "${RELEASE_NAME:0:10}.*portal-web" | awk '{print $1}')
+
 # obtain endpoint info from APIC v10 routes
-APIM_UI_EP=$(oc get route -n $NAMESPACE ${RELEASE_NAME}-mgmt-api-manager -o jsonpath='{.spec.host}')
-CMC_UI_EP=$(oc get route -n $NAMESPACE ${RELEASE_NAME}-mgmt-admin -o jsonpath='{.spec.host}')
-C_API_EP=$(oc get route -n $NAMESPACE ${RELEASE_NAME}-mgmt-consumer-api -o jsonpath='{.spec.host}')
-API_EP=$(oc get route -n $NAMESPACE ${RELEASE_NAME}-mgmt-platform-api -o jsonpath='{.spec.host}')
-PTL_WEB_EP=$(oc get route -n $NAMESPACE ${RELEASE_NAME}-ptl-portal-web -o jsonpath='{.spec.host}')
+APIM_UI_EP=$(oc get route -n $NAMESPACE ${APIM_UI_RESOURCE_NAME} -o jsonpath='{.spec.host}')
+CMC_UI_EP=$(oc get route -n $NAMESPACE ${CMC_UI_RESOURCE_NAME} -o jsonpath='{.spec.host}')
+C_API_EP=$(oc get route -n $NAMESPACE ${C_API_RESOURCE_NAME} -o jsonpath='{.spec.host}')
+API_EP=$(oc get route -n $NAMESPACE ${API_RESOURCE_NAME} -o jsonpath='{.spec.host}')
+PTL_WEB_EP=$(oc get route -n $NAMESPACE ${PLT_WEB_RESOURCE_NAME} -o jsonpath='{.spec.host}')
 
 admin_idp=admin/default-idp-1
 admin_password=$(oc get secret -n $NAMESPACE ${RELEASE_NAME}-mgmt-admin-pass -o json | jq -r .data.password | base64 --decode)
@@ -413,7 +420,7 @@ PROVIDER_CREDENTIALS=$(oc get secret $PROVIDER_SECRET_NAME -n $NAMESPACE -o json
 ACE_CREDENTIALS=$(oc get secret $ACE_REGISTRATION_SECRET_NAME -n $NAMESPACE -o json | jq .data)
 
 for i in $(seq 1 60); do
-  PORTAL_WWW_POD=$(oc get pods -n $NAMESPACE | grep -m1 "${RELEASE_NAME}-ptl.*www" | awk '{print $1}')
+  PORTAL_WWW_POD=$(oc get pods -n $NAMESPACE | grep -m1 "${RELEASE_NAME:0:10}-.*-www" | awk '{print $1}')
   $DEBUG && echo "[DEBUG] PORTAL_WWW_POD=${PORTAL_WWW_POD}"
   PORTAL_SITE_UUID=$(oc exec -n $NAMESPACE -it $PORTAL_WWW_POD -c admin -- /opt/ibm/bin/list_sites | awk '{print $1}')
   $DEBUG && echo "[DEBUG] PORTAL_SITE_UUID=${PORTAL_SITE_UUID}"


### PR DESCRIPTION
Currently, the APIC configure script does not work well when the length of the release name is greater than 10 characters. This is because APIC restricts the name to something smaller. For instance, the release name `cp4i-apic-apic` gets concatenated into `cp4i-apic-` followed by a random hash. This results in this script not functioning, since it does not account for the concatenation. 

**Example if release name = `ademo`:**
![Image 28-03-2023 at 11 25](https://user-images.githubusercontent.com/44068823/228207558-94bb6e88-67ba-4b01-bd00-c2ee1d14dbed.jpg)

**Example if release name is = `cp4i-apic-apic`:**
![Image 28-03-2023 at 11 27](https://user-images.githubusercontent.com/44068823/228207938-14f2356d-777b-4bf5-84ac-6c926f7d996f.jpg)

As is evident above, the name of the routes change depending on the length. This PR therefore changes the regex to take this into account.